### PR TITLE
Fix custom panel registration on Home Assistant 2026.8.3

### DIFF
--- a/custom_components/bindhome/manifest.json
+++ b/custom_components/bindhome/manifest.json
@@ -1,6 +1,9 @@
 {
   "domain": "bindhome",
   "name": "BindHome",
+  "after_dependencies": [
+    "panel_custom"
+  ],
   "codeowners": [
     "@alessbarb"
   ],

--- a/custom_components/bindhome/panel/__init__.py
+++ b/custom_components/bindhome/panel/__init__.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import Final
 
-from homeassistant.components import frontend
+from homeassistant.components import frontend, panel_custom
 from homeassistant.components.http.server import StaticPathConfig
 from homeassistant.core import HomeAssistant
 
@@ -46,16 +46,13 @@ async def async_register_panel(hass: HomeAssistant) -> None:
             )
         panel_data[STATIC_REGISTERED_KEY] = True
 
-    frontend.async_register_built_in_panel(
+    await panel_custom.async_register_panel(
         hass,
-        component_name="custom",
+        frontend_url_path=PANEL_URL_PATH,
+        webcomponent_name=PANEL_COMPONENT_NAME,
         sidebar_title=PANEL_TITLE,
         sidebar_icon=PANEL_ICON,
-        frontend_url_path=PANEL_URL_PATH,
-        config={
-            "_name": PANEL_COMPONENT_NAME,
-            "js_url": f"/{PANEL_URL_PATH}_static/{BUNDLE_FILENAME}",
-        },
+        js_url=f"/{PANEL_URL_PATH}_static/{BUNDLE_FILENAME}",
         require_admin=True,
     )
 

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -26,20 +26,22 @@ async def test_panel_registration(hass: HomeAssistant) -> None:
     """Test panel registration registers custom panel and static path."""
     with (
         patch(
-            "homeassistant.components.frontend.async_register_built_in_panel"
+            "custom_components.bindhome.panel.panel_custom.async_register_panel"
         ) as mock_register_panel,
         patch.object(hass, "http", MagicMock()) as mock_http,
     ):
         mock_http.async_register_static_paths = AsyncMock()
         await async_register_panel(hass)
 
-        mock_register_panel.assert_called_once()
-        args, kwargs = mock_register_panel.call_args
-        assert kwargs["component_name"] == "custom"
-        assert kwargs["frontend_url_path"] == "bindhome"
-        assert kwargs["config"]["_name"] == "bindhome-panel"
-        assert kwargs["config"]["js_url"] == "/bindhome_static/bindhome-panel.js"
-        assert kwargs["require_admin"] is True
+        mock_register_panel.assert_awaited_once_with(
+            hass,
+            frontend_url_path="bindhome",
+            webcomponent_name="bindhome-panel",
+            sidebar_title="BindHome",
+            sidebar_icon="mdi:home-switch",
+            js_url="/bindhome_static/bindhome-panel.js",
+            require_admin=True,
+        )
 
         mock_http.async_register_static_paths.assert_called_once()
         (path_configs,), _ = mock_http.async_register_static_paths.call_args
@@ -54,7 +56,7 @@ async def test_panel_registration_is_idempotent(hass: HomeAssistant) -> None:
     """Test repeated setup does not register the panel or static path twice."""
     with (
         patch(
-            "homeassistant.components.frontend.async_register_built_in_panel"
+            "custom_components.bindhome.panel.panel_custom.async_register_panel"
         ) as mock_register_panel,
         patch(
             "homeassistant.components.frontend.async_panel_exists",
@@ -66,7 +68,7 @@ async def test_panel_registration_is_idempotent(hass: HomeAssistant) -> None:
         await async_register_panel(hass)
         await async_register_panel(hass)
 
-        mock_register_panel.assert_called_once()
+        mock_register_panel.assert_awaited_once()
         mock_http.async_register_static_paths.assert_awaited_once()
 
 
@@ -82,11 +84,11 @@ async def test_panel_registration_missing_bundle(hass: HomeAssistant) -> None:
             new=MagicMock(__truediv__=lambda self, other: mock_bundle_path),
         ),
         patch(
-            "homeassistant.components.frontend.async_register_built_in_panel"
+            "custom_components.bindhome.panel.panel_custom.async_register_panel"
         ) as mock_register_panel,
     ):
         await async_register_panel(hass)
-        mock_register_panel.assert_not_called()
+        mock_register_panel.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix BindHome panel registration so Home Assistant's custom-panel frontend receives the `_panel_custom` configuration shape it expects.

## Changes

- register the panel through `panel_custom.async_register_panel()` instead of calling `frontend.async_register_built_in_panel()` directly
- declare `panel_custom` as an `after_dependency`, avoiding forced frontend setup in the test harness
- update panel tests to validate the Home Assistant custom-panel API contract

## Runtime defect

This addresses RA-07: the BindHome sidebar entry was registered and the static bundle was served successfully, but the panel rendered blank because the custom-panel loader configuration was malformed.

Runtime evidence before the fix:

- static bundle: HTTP 200
- size: 38,200 bytes
- SHA-256: `5c0e5cafd0ef78e2a5195895e8ab1c9954ba18d438adfe2b6847581ff4d099bd`
- Home Assistant Core API healthy
- BindHome panel route/sidebar registered
- panel content blank

## Local validation

- `133 passed`
- Ruff check passed
- Ruff format check passed
- `git diff --check` passed
- frontend bundle unchanged

The VM has not been redeployed with this commit yet; runtime acceptance will continue only after CI is green.