### PR TITLE
Fix logical light color mode

### DIFF
--- a/custom_components/bindhome/light.py
+++ b/custom_components/bindhome/light.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from homeassistant.components.light import LightEntity
+from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -40,6 +40,8 @@ class BindHomeLight(LightEntity):
     """A stable logical light backed by the asset's current binding."""
 
     _attr_should_poll = True
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = {ColorMode.ONOFF}
 
     def __init__(
         self, hass: HomeAssistant, asset: Asset, resolver: BindingResolver

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from homeassistant.components.light import ColorMode
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from custom_components.bindhome.light import BindHomeLight
@@ -132,3 +133,20 @@ async def test_assets_without_on_off_are_not_eligible() -> None:
     asset = _asset(registry, ["dimming"])
 
     assert BindHomeLight.is_eligible(asset) is False
+
+
+async def test_logical_light_exposes_valid_on_off_light_attributes(
+    hass: HomeAssistant,
+) -> None:
+    """Expose the Home Assistant light color-mode contract."""
+    registry = BindHomeRegistry()
+    asset = _asset(registry, ["on_off"])
+    _binding(registry, asset, "switch.hardware")
+    hass.states.async_set("switch.hardware", "on")
+
+    logical = _logical_light(hass, registry, asset)
+    await logical.async_update()
+
+    assert logical.supported_color_modes == {ColorMode.ONOFF}
+    assert logical.color_mode is ColorMode.ONOFF
+    assert logical.state_attributes["color_mode"] == ColorMode.ONOFF


### PR DESCRIPTION
Closes the RA-06 runtime acceptance gap for the BindHome logical light by explicitly declaring ON/OFF color mode support.

Validated in the live Home Assistant runtime as part of RA-06, including persistence across Core restart.

Changes:
- declare the logical light color mode correctly
- add regression coverage in `tests/test_light.py`