### PR TITLE
Runtime registry reconciliation and public asset updates

### DIFF
--- a/custom_components/bindhome/const.py
+++ b/custom_components/bindhome/const.py
@@ -9,6 +9,8 @@ STORAGE_KEY: Final = "bindhome.registry"
 STORAGE_VERSION: Final = 1
 REGISTRY_SCHEMA_VERSION: Final = 1
 
+SIGNAL_REGISTRY_CHANGED: Final = f"{DOMAIN}_registry_changed"
+
 SERVICE_CREATE_ASSET: Final = "create_asset"
 SERVICE_DELETE_ASSET: Final = "delete_asset"
 SERVICE_ADD_RELATION: Final = "add_relation"

--- a/custom_components/bindhome/const.py
+++ b/custom_components/bindhome/const.py
@@ -12,6 +12,7 @@ REGISTRY_SCHEMA_VERSION: Final = 1
 SIGNAL_REGISTRY_CHANGED: Final = f"{DOMAIN}_registry_changed"
 
 SERVICE_CREATE_ASSET: Final = "create_asset"
+SERVICE_UPDATE_ASSET: Final = "update_asset"
 SERVICE_DELETE_ASSET: Final = "delete_asset"
 SERVICE_ADD_RELATION: Final = "add_relation"
 SERVICE_REMOVE_RELATION: Final = "remove_relation"

--- a/custom_components/bindhome/light.py
+++ b/custom_components/bindhome/light.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import asyncio
 from typing import Any
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, SIGNAL_REGISTRY_CHANGED
 from .manager import BindHomeManager
 from .models import Asset
 from .resolver import (
@@ -25,14 +28,97 @@ _SUPPORTED_DOMAINS = frozenset({"switch", "light"})
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: Any, async_add_entities: Callable
+    hass: HomeAssistant,
+    entry: Any,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up logical lights for all eligible BindHome assets."""
+    """Set up and dynamically reconcile BindHome logical lights."""
     manager: BindHomeManager = entry.runtime_data
-    async_add_entities(
-        BindHomeLight(hass, asset, manager.resolver)
-        for asset in manager.registry.assets.values()
-        if BindHomeLight.is_eligible(asset)
+    entity_registry = er.async_get(hass)
+
+    entities: dict[str, BindHomeLight] = {}
+    reconcile_lock = asyncio.Lock()
+
+    async def async_reconcile() -> None:
+        """Reconcile logical lights against the current BindHome registry."""
+        async with reconcile_lock:
+            eligible_assets = {
+                asset.id: asset
+                for asset in manager.registry.assets.values()
+                if BindHomeLight.is_eligible(asset)
+            }
+
+            current_ids = set(entities)
+            eligible_ids = set(eligible_assets)
+
+            # Remove logical entities whose assets no longer expose on_off.
+            for asset_id in sorted(current_ids - eligible_ids):
+                entity = entities.pop(asset_id)
+
+                if entity.hass is not None:
+                    platform = entity.platform
+                    await entity.async_remove(force_remove=True)
+
+                    # Direct force-removal bypasses
+                    # EntityPlatform.async_remove_entity(), so mirror its polling
+                    # cleanup when no polling entities remain.
+                    if not any(
+                        candidate.should_poll
+                        for candidate in platform.entities.values()
+                    ):
+                        platform.async_unsub_polling()
+
+                entity_id = entity_registry.async_get_entity_id(
+                    "light",
+                    DOMAIN,
+                    f"{DOMAIN}_{asset_id}",
+                )
+                if entity_id is not None:
+                    entity_registry.async_remove(entity_id)
+
+            # Refresh metadata for entities which continue to exist.
+            for asset_id in sorted(current_ids & eligible_ids):
+                asset = eligible_assets[asset_id]
+                entity = entities[asset_id]
+
+                entity.update_asset(asset)
+
+                entity_id = entity_registry.async_get_entity_id(
+                    "light",
+                    DOMAIN,
+                    entity.unique_id,
+                )
+                if entity_id is not None:
+                    entity_registry.async_update_entity(
+                        entity_id,
+                        area_id=asset.area_id,
+                        original_name=asset.name,
+                    )
+
+            # Add newly eligible assets.
+            new_entities: list[BindHomeLight] = []
+
+            for asset_id in sorted(eligible_ids - current_ids):
+                asset = eligible_assets[asset_id]
+                entity = BindHomeLight(
+                    hass,
+                    asset,
+                    manager.resolver,
+                )
+                entities[asset_id] = entity
+                new_entities.append(entity)
+
+            if new_entities:
+                async_add_entities(new_entities)
+
+    await async_reconcile()
+
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            SIGNAL_REGISTRY_CHANGED,
+            async_reconcile,
+        )
     )
 
 
@@ -59,6 +145,17 @@ class BindHomeLight(LightEntity):
     def asset_id(self) -> str:
         """Return the stable BindHome asset identity."""
         return self._asset.id
+
+    def update_asset(self, asset: Asset) -> None:
+        """Refresh mutable asset metadata while preserving entity identity."""
+        if asset.id != self._asset.id:
+            raise ValueError("Cannot replace the stable asset identity")
+
+        self._asset = asset
+        self._attr_name = asset.name
+
+        if self.hass is not None:
+            self.async_write_ha_state()
 
     @staticmethod
     def is_eligible(asset: Asset) -> bool:

--- a/custom_components/bindhome/manager.py
+++ b/custom_components/bindhome/manager.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
+from .const import SIGNAL_REGISTRY_CHANGED
 from .models import Asset, Binding, Relation
 from .registry import BindHomeRegistry
 from .resolver import BindingResolver, HomeAssistantEntityProbe
@@ -26,6 +28,11 @@ class BindHomeManager:
     def resolver(self) -> BindingResolver:
         """Return a resolver bound to the current registry and Home Assistant."""
         return BindingResolver(self.registry, self._probe)
+
+    async def _async_persist_and_notify(self) -> None:
+        """Persist the registry and notify runtime consumers."""
+        await self._store.async_save(self.registry)
+        async_dispatcher_send(self.hass, SIGNAL_REGISTRY_CHANGED)
 
     async def async_load(self) -> None:
         """Load persisted registry state."""
@@ -51,14 +58,37 @@ class BindHomeManager:
                     capabilities=capabilities,
                 )
             )
-            await self._store.async_save(self.registry)
+            await self._async_persist_and_notify()
+            return asset
+
+    async def async_update_asset(
+        self,
+        *,
+        asset_id: str,
+        name: str,
+        asset_type: str,
+        code: str | None,
+        area_id: str | None,
+        capabilities: list[str],
+    ) -> Asset:
+        """Update and persist an asset without changing its identity."""
+        async with self._mutation_lock:
+            asset = self.registry.update_asset(
+                asset_id,
+                name=name,
+                asset_type=asset_type,
+                code=code,
+                area_id=area_id,
+                capabilities=capabilities,
+            )
+            await self._async_persist_and_notify()
             return asset
 
     async def async_delete_asset(self, asset_id: str) -> None:
         """Delete and persist an asset."""
         async with self._mutation_lock:
             self.registry.delete_asset(asset_id)
-            await self._store.async_save(self.registry)
+            await self._async_persist_and_notify()
 
     async def async_add_relation(
         self, *, source_asset_id: str, relation_type: str, target_asset_id: str
@@ -72,14 +102,14 @@ class BindHomeManager:
                     target_asset_id=target_asset_id,
                 )
             )
-            await self._store.async_save(self.registry)
+            await self._async_persist_and_notify()
             return relation
 
     async def async_remove_relation(self, relation_id: str) -> None:
         """Remove and persist a topology relation."""
         async with self._mutation_lock:
             self.registry.remove_relation(relation_id)
-            await self._store.async_save(self.registry)
+            await self._async_persist_and_notify()
 
     async def async_set_binding(
         self,
@@ -99,11 +129,11 @@ class BindHomeManager:
                     role=role,
                 )
             )
-            await self._store.async_save(self.registry)
+            await self._async_persist_and_notify()
             return binding
 
     async def async_remove_binding(self, binding_id: str) -> None:
         """Remove and persist a binding."""
         async with self._mutation_lock:
             self.registry.remove_binding(binding_id)
-            await self._store.async_save(self.registry)
+            await self._async_persist_and_notify()

--- a/custom_components/bindhome/models.py
+++ b/custom_components/bindhome/models.py
@@ -89,6 +89,37 @@ class Asset:
         )
         return replace(self, capabilities=normalized)
 
+    def with_updates(
+        self,
+        *,
+        name: str,
+        asset_type: str,
+        code: str | None,
+        area_id: str | None,
+        capabilities: tuple[str, ...] | list[str],
+    ) -> Asset:
+        """Return an updated asset while preserving its stable identity."""
+        normalized_capabilities = tuple(
+            sorted(
+                {
+                    normalize_identifier(capability, "capability")
+                    for capability in capabilities
+                }
+            )
+        )
+        return replace(
+            self,
+            name=normalize_non_empty(name, "name"),
+            asset_type=normalize_identifier(asset_type, "asset_type"),
+            code=normalize_non_empty(code, "code") if code is not None else None,
+            area_id=(
+                normalize_non_empty(area_id, "area_id")
+                if area_id is not None
+                else None
+            ),
+            capabilities=normalized_capabilities,
+        )
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize the asset."""
         return {

--- a/custom_components/bindhome/models.py
+++ b/custom_components/bindhome/models.py
@@ -113,9 +113,7 @@ class Asset:
             asset_type=normalize_identifier(asset_type, "asset_type"),
             code=normalize_non_empty(code, "code") if code is not None else None,
             area_id=(
-                normalize_non_empty(area_id, "area_id")
-                if area_id is not None
-                else None
+                normalize_non_empty(area_id, "area_id") if area_id is not None else None
             ),
             capabilities=normalized_capabilities,
         )

--- a/custom_components/bindhome/registry.py
+++ b/custom_components/bindhome/registry.py
@@ -68,17 +68,14 @@ class BindHomeRegistry:
             existing.id != asset_id and existing.code == updated.code
             for existing in self.assets.values()
         ):
-            raise RegistryConflictError(
-                f"Asset code {updated.code} already exists"
-            )
+            raise RegistryConflictError(f"Asset code {updated.code} already exists")
 
         removed = set(asset.capabilities) - set(updated.capabilities)
         if removed:
             blocking = [
                 binding
                 for binding in self.bindings.values()
-                if binding.asset_id == asset_id
-                and binding.capability in removed
+                if binding.asset_id == asset_id and binding.capability in removed
             ]
             if blocking:
                 raise RegistryConflictError(

--- a/custom_components/bindhome/registry.py
+++ b/custom_components/bindhome/registry.py
@@ -44,25 +44,63 @@ class BindHomeRegistry:
         self.assets[asset.id] = asset
         return asset
 
-    def update_asset_capabilities(
-        self, asset_id: str, capabilities: tuple[str, ...] | list[str]
+    def update_asset(
+        self,
+        asset_id: str,
+        *,
+        name: str,
+        asset_type: str,
+        code: str | None,
+        area_id: str | None,
+        capabilities: tuple[str, ...] | list[str],
     ) -> Asset:
-        """Replace an asset capability set if no binding would become orphaned."""
+        """Update an asset while preserving its stable identity."""
         asset = self.get_asset(asset_id)
-        updated = asset.with_capabilities(capabilities)
+        updated = asset.with_updates(
+            name=name,
+            asset_type=asset_type,
+            code=code,
+            area_id=area_id,
+            capabilities=capabilities,
+        )
+
+        if updated.code and any(
+            existing.id != asset_id and existing.code == updated.code
+            for existing in self.assets.values()
+        ):
+            raise RegistryConflictError(
+                f"Asset code {updated.code} already exists"
+            )
+
         removed = set(asset.capabilities) - set(updated.capabilities)
         if removed:
             blocking = [
                 binding
                 for binding in self.bindings.values()
-                if binding.asset_id == asset_id and binding.capability in removed
+                if binding.asset_id == asset_id
+                and binding.capability in removed
             ]
             if blocking:
                 raise RegistryConflictError(
                     "Cannot remove capabilities that still have active bindings"
                 )
+
         self.assets[asset_id] = updated
         return updated
+
+    def update_asset_capabilities(
+        self, asset_id: str, capabilities: tuple[str, ...] | list[str]
+    ) -> Asset:
+        """Replace capabilities while preserving the existing asset metadata."""
+        asset = self.get_asset(asset_id)
+        return self.update_asset(
+            asset_id,
+            name=asset.name,
+            asset_type=asset.asset_type,
+            code=asset.code,
+            area_id=asset.area_id,
+            capabilities=capabilities,
+        )
 
     def delete_asset(self, asset_id: str) -> None:
         """Delete an unreferenced asset."""

--- a/custom_components/bindhome/services.py
+++ b/custom_components/bindhome/services.py
@@ -24,6 +24,7 @@ from .const import (
     SERVICE_REMOVE_BINDING,
     SERVICE_REMOVE_RELATION,
     SERVICE_SET_BINDING,
+    SERVICE_UPDATE_ASSET,
 )
 from .manager import BindHomeManager
 from .models import ModelValidationError
@@ -37,6 +38,16 @@ _CREATE_ASSET_SCHEMA = vol.Schema(
         vol.Optional("code"): cv.string,
         vol.Optional("area_id"): cv.string,
         vol.Optional("capabilities", default=[]): [cv.string],
+    }
+)
+_UPDATE_ASSET_SCHEMA = vol.Schema(
+    {
+        vol.Required("asset_id"): cv.string,
+        vol.Optional("name"): cv.string,
+        vol.Optional("asset_type"): cv.string,
+        vol.Optional("code"): vol.Any(None, cv.string),
+        vol.Optional("area_id"): vol.Any(None, cv.string),
+        vol.Optional("capabilities"): [cv.string],
     }
 )
 _DELETE_ASSET_SCHEMA = vol.Schema({vol.Required("asset_id"): cv.string})
@@ -92,6 +103,40 @@ def async_register_services(hass: HomeAssistant) -> None:
             )
         except (ModelValidationError, RegistryError) as err:
             raise _translate_registry_error(err) from err
+        return {"asset": asset.to_dict()} if call.return_response else None
+
+    async def update_asset(call: ServiceCall) -> ServiceResponse | None:
+        manager = _get_manager(hass)
+
+        try:
+            existing = manager.registry.get_asset(call.data["asset_id"])
+
+            area_id = call.data.get("area_id", existing.area_id)
+            validate_area(hass, area_id)
+
+            asset = await manager.async_update_asset(
+                asset_id=existing.id,
+                name=call.data.get("name", existing.name),
+                asset_type=call.data.get(
+                    "asset_type",
+                    existing.asset_type,
+                ),
+                code=call.data.get("code", existing.code),
+                area_id=area_id,
+                capabilities=list(
+                    call.data.get(
+                        "capabilities",
+                        existing.capabilities,
+                    )
+                ),
+            )
+        except (
+            ModelValidationError,
+            RegistryError,
+            ServiceValidationError,
+        ) as err:
+            raise _translate_registry_error(err) from err
+
         return {"asset": asset.to_dict()} if call.return_response else None
 
     async def delete_asset(call: ServiceCall) -> ServiceResponse | None:
@@ -162,6 +207,13 @@ def async_register_services(hass: HomeAssistant) -> None:
         SERVICE_CREATE_ASSET,
         create_asset,
         schema=_CREATE_ASSET_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_UPDATE_ASSET,
+        update_asset,
+        schema=_UPDATE_ASSET_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(

--- a/custom_components/bindhome/services.yaml
+++ b/custom_components/bindhome/services.yaml
@@ -18,6 +18,28 @@ create_asset:
       selector:
         object:
 
+update_asset:
+  fields:
+    asset_id:
+      required: true
+      selector:
+        text:
+    name:
+      selector:
+        text:
+    asset_type:
+      selector:
+        text:
+    code:
+      selector:
+        text:
+    area_id:
+      selector:
+        area:
+    capabilities:
+      selector:
+        object:
+
 delete_asset:
   fields:
     asset_id:

--- a/custom_components/bindhome/websocket.py
+++ b/custom_components/bindhome/websocket.py
@@ -159,9 +159,7 @@ async def ws_asset_update(
             asset_type=msg.get("asset_type", existing.asset_type),
             code=msg.get("code", existing.code),
             area_id=area_id,
-            capabilities=list(
-                msg.get("capabilities", existing.capabilities)
-            ),
+            capabilities=list(msg.get("capabilities", existing.capabilities)),
         )
     except (
         ModelValidationError,

--- a/custom_components/bindhome/websocket.py
+++ b/custom_components/bindhome/websocket.py
@@ -36,6 +36,7 @@ from .validation import validate_area, validate_entity
 
 WS_REGISTRY_GET = f"{DOMAIN}/registry/get"
 WS_ASSET_CREATE = f"{DOMAIN}/assets/create"
+WS_ASSET_UPDATE = f"{DOMAIN}/assets/update"
 WS_ASSET_DELETE = f"{DOMAIN}/assets/delete"
 WS_RELATION_CREATE = f"{DOMAIN}/relations/create"
 WS_RELATION_DELETE = f"{DOMAIN}/relations/delete"
@@ -123,6 +124,53 @@ async def ws_asset_create(
     except (ModelValidationError, RegistryError, ServiceValidationError) as err:
         _send_error(connection, msg, err)
         return
+    connection.send_result(msg["id"], {"asset": asset.to_dict()})
+
+
+@require_admin
+@websocket_command(
+    {
+        vol.Required("type"): WS_ASSET_UPDATE,
+        vol.Required("asset_id"): cv.string,
+        vol.Optional("name"): cv.string,
+        vol.Optional("asset_type"): cv.string,
+        vol.Optional("code"): vol.Any(None, cv.string),
+        vol.Optional("area_id"): vol.Any(None, cv.string),
+        vol.Optional("capabilities"): [cv.string],
+    }
+)
+@async_response
+async def ws_asset_update(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Partially update an asset while preserving its stable identity."""
+    try:
+        manager = _get_manager(hass)
+        existing = manager.registry.get_asset(msg["asset_id"])
+
+        area_id = msg.get("area_id", existing.area_id)
+        validate_area(hass, area_id)
+
+        asset = await manager.async_update_asset(
+            asset_id=existing.id,
+            name=msg.get("name", existing.name),
+            asset_type=msg.get("asset_type", existing.asset_type),
+            code=msg.get("code", existing.code),
+            area_id=area_id,
+            capabilities=list(
+                msg.get("capabilities", existing.capabilities)
+            ),
+        )
+    except (
+        ModelValidationError,
+        RegistryError,
+        ServiceValidationError,
+    ) as err:
+        _send_error(connection, msg, err)
+        return
+
     connection.send_result(msg["id"], {"asset": asset.to_dict()})
 
 
@@ -390,6 +438,7 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     for handler in (
         ws_registry_get,
         ws_asset_create,
+        ws_asset_update,
         ws_asset_delete,
         ws_relation_create,
         ws_relation_delete,

--- a/tests/test_asset_updates.py
+++ b/tests/test_asset_updates.py
@@ -1,0 +1,146 @@
+"""Tests for asset updates and registry mutation notifications."""
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from custom_components.bindhome.const import SIGNAL_REGISTRY_CHANGED
+from custom_components.bindhome.manager import BindHomeManager
+from custom_components.bindhome.models import Asset, Binding
+from custom_components.bindhome.registry import (
+    BindHomeRegistry,
+    RegistryConflictError,
+)
+
+
+def test_update_asset_preserves_identity_and_updates_metadata() -> None:
+    registry = BindHomeRegistry()
+    asset = registry.add_asset(
+        Asset.create(
+            name="Old light",
+            asset_type="light_point",
+            code="OLD-01",
+            area_id="old_area",
+            capabilities=["on_off"],
+        )
+    )
+
+    updated = registry.update_asset(
+        asset.id,
+        name="New light",
+        asset_type="ceiling_light",
+        code="NEW-01",
+        area_id="new_area",
+        capabilities=["on_off", "dimming"],
+    )
+
+    assert updated.id == asset.id
+    assert updated.name == "New light"
+    assert updated.asset_type == "ceiling_light"
+    assert updated.code == "NEW-01"
+    assert updated.area_id == "new_area"
+    assert updated.capabilities == ("dimming", "on_off")
+    assert registry.get_asset(asset.id) == updated
+
+
+def test_update_asset_rejects_duplicate_code() -> None:
+    registry = BindHomeRegistry()
+    first = registry.add_asset(
+        Asset.create(name="First", asset_type="socket", code="SOCK-01")
+    )
+    second = registry.add_asset(
+        Asset.create(name="Second", asset_type="socket", code="SOCK-02")
+    )
+
+    with pytest.raises(
+        RegistryConflictError,
+        match="Asset code SOCK-01 already exists",
+    ):
+        registry.update_asset(
+            second.id,
+            name=second.name,
+            asset_type=second.asset_type,
+            code=first.code,
+            area_id=second.area_id,
+            capabilities=list(second.capabilities),
+        )
+
+
+def test_update_asset_cannot_orphan_binding() -> None:
+    registry = BindHomeRegistry()
+    asset = registry.add_asset(
+        Asset.create(
+            name="Light",
+            asset_type="light_point",
+            capabilities=["on_off", "dimming"],
+        )
+    )
+    registry.set_binding(
+        Binding.create(
+            asset_id=asset.id,
+            capability="on_off",
+            entity_id="switch.backend",
+        )
+    )
+
+    with pytest.raises(
+        RegistryConflictError,
+        match="Cannot remove capabilities that still have active bindings",
+    ):
+        registry.update_asset(
+            asset.id,
+            name=asset.name,
+            asset_type=asset.asset_type,
+            code=asset.code,
+            area_id=asset.area_id,
+            capabilities=["dimming"],
+        )
+
+
+async def test_manager_update_persists_and_dispatches(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+
+    notifications: list[None] = []
+    unsubscribe = async_dispatcher_connect(
+        hass,
+        SIGNAL_REGISTRY_CHANGED,
+        lambda: notifications.append(None),
+    )
+
+    asset = await manager.async_create_asset(
+        name="Original",
+        asset_type="light_point",
+        code="LGT-01",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await hass.async_block_till_done()
+
+    updated = await manager.async_update_asset(
+        asset_id=asset.id,
+        name="Renamed",
+        asset_type="ceiling_light",
+        code="LGT-02",
+        area_id="living_room",
+        capabilities=["on_off", "dimming"],
+    )
+    await hass.async_block_till_done()
+
+    assert updated.id == asset.id
+    assert len(notifications) == 2
+
+    reloaded = BindHomeManager(hass)
+    await reloaded.async_load()
+    persisted = reloaded.registry.get_asset(asset.id)
+
+    assert persisted.id == asset.id
+    assert persisted.name == "Renamed"
+    assert persisted.asset_type == "ceiling_light"
+    assert persisted.code == "LGT-02"
+    assert persisted.area_id == "living_room"
+    assert persisted.capabilities == ("dimming", "on_off")
+
+    unsubscribe()

--- a/tests/test_light_reconciliation.py
+++ b/tests/test_light_reconciliation.py
@@ -179,11 +179,14 @@ async def test_removing_on_off_removes_logical_light_cleanly(
     )
     await hass.async_block_till_done()
 
-    assert registry.async_get_entity_id(
-        "light",
-        DOMAIN,
-        unique_id,
-    ) is None
+    assert (
+        registry.async_get_entity_id(
+            "light",
+            DOMAIN,
+            unique_id,
+        )
+        is None
+    )
     assert hass.states.get(entity_id) is None
 
 
@@ -272,9 +275,12 @@ async def test_deleting_asset_removes_logical_light_without_reload(
     await manager.async_delete_asset(asset.id)
     await hass.async_block_till_done()
 
-    assert registry.async_get_entity_id(
-        "light",
-        DOMAIN,
-        unique_id,
-    ) is None
+    assert (
+        registry.async_get_entity_id(
+            "light",
+            DOMAIN,
+            unique_id,
+        )
+        is None
+    )
     assert hass.states.get(entity_id) is None

--- a/tests/test_light_reconciliation.py
+++ b/tests/test_light_reconciliation.py
@@ -1,0 +1,280 @@
+"""Runtime reconciliation tests for BindHome logical lights."""
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bindhome import async_setup
+from custom_components.bindhome.const import DOMAIN
+
+
+@pytest.fixture
+async def bindhome_entry(hass: HomeAssistant):
+    """Set up BindHome and always cleanly unload its entity platforms."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    await async_setup(hass, {})
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    yield entry
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_asset_created_after_setup_adds_logical_light(
+    hass: HomeAssistant,
+    bindhome_entry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+
+    asset = await manager.async_create_asset(
+        name="Dynamic light",
+        asset_type="light_point",
+        code="DYN-01",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        f"{DOMAIN}_{asset.id}",
+    )
+
+    assert entity_id is not None
+    assert hass.states.get(entity_id) is not None
+
+
+async def test_existing_asset_becomes_logical_light_when_on_off_added(
+    hass: HomeAssistant,
+    bindhome_entry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+
+    asset = await manager.async_create_asset(
+        name="Initially passive",
+        asset_type="light_point",
+        code=None,
+        area_id=None,
+        capabilities=[],
+    )
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    unique_id = f"{DOMAIN}_{asset.id}"
+
+    assert registry.async_get_entity_id("light", DOMAIN, unique_id) is None
+
+    await manager.async_update_asset(
+        asset_id=asset.id,
+        name=asset.name,
+        asset_type=asset.asset_type,
+        code=asset.code,
+        area_id=asset.area_id,
+        capabilities=["on_off"],
+    )
+    await hass.async_block_till_done()
+
+    entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        unique_id,
+    )
+
+    assert entity_id is not None
+    assert hass.states.get(entity_id) is not None
+
+
+async def test_logical_light_metadata_updates_without_identity_change(
+    hass: HomeAssistant,
+    bindhome_entry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+
+    asset = await manager.async_create_asset(
+        name="Old name",
+        asset_type="light_point",
+        code="LGT-OLD",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    unique_id = f"{DOMAIN}_{asset.id}"
+    entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        unique_id,
+    )
+
+    assert entity_id is not None
+
+    await manager.async_update_asset(
+        asset_id=asset.id,
+        name="New name",
+        asset_type="ceiling_light",
+        code="LGT-NEW",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await hass.async_block_till_done()
+
+    updated_entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        unique_id,
+    )
+
+    assert updated_entity_id == entity_id
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes["friendly_name"] == "New name"
+
+    registry_entry = registry.async_get(entity_id)
+    assert registry_entry is not None
+    assert registry_entry.original_name == "New name"
+
+
+async def test_removing_on_off_removes_logical_light_cleanly(
+    hass: HomeAssistant,
+    bindhome_entry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+
+    asset = await manager.async_create_asset(
+        name="Temporary logical light",
+        asset_type="light_point",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    unique_id = f"{DOMAIN}_{asset.id}"
+    entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        unique_id,
+    )
+
+    assert entity_id is not None
+    assert hass.states.get(entity_id) is not None
+
+    await manager.async_update_asset(
+        asset_id=asset.id,
+        name=asset.name,
+        asset_type=asset.asset_type,
+        code=asset.code,
+        area_id=asset.area_id,
+        capabilities=[],
+    )
+    await hass.async_block_till_done()
+
+    assert registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        unique_id,
+    ) is None
+    assert hass.states.get(entity_id) is None
+
+
+async def test_removed_capability_can_be_readded_with_same_entity_id(
+    hass: HomeAssistant,
+    bindhome_entry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+
+    asset = await manager.async_create_asset(
+        name="Recreatable light",
+        asset_type="light_point",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    unique_id = f"{DOMAIN}_{asset.id}"
+
+    original_entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        unique_id,
+    )
+    assert original_entity_id is not None
+
+    await manager.async_update_asset(
+        asset_id=asset.id,
+        name=asset.name,
+        asset_type=asset.asset_type,
+        code=asset.code,
+        area_id=asset.area_id,
+        capabilities=[],
+    )
+    await hass.async_block_till_done()
+
+    await manager.async_update_asset(
+        asset_id=asset.id,
+        name=asset.name,
+        asset_type=asset.asset_type,
+        code=asset.code,
+        area_id=asset.area_id,
+        capabilities=["on_off"],
+    )
+    await hass.async_block_till_done()
+
+    restored_entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        unique_id,
+    )
+
+    assert restored_entity_id == original_entity_id
+    assert hass.states.get(restored_entity_id) is not None
+
+
+async def test_deleting_asset_removes_logical_light_without_reload(
+    hass: HomeAssistant,
+    bindhome_entry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+
+    asset = await manager.async_create_asset(
+        name="Disposable light",
+        asset_type="light_point",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    unique_id = f"{DOMAIN}_{asset.id}"
+
+    entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        unique_id,
+    )
+
+    assert entity_id is not None
+    assert hass.states.get(entity_id) is not None
+
+    await manager.async_delete_asset(asset.id)
+    await hass.async_block_till_done()
+
+    assert registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        unique_id,
+    ) is None
+    assert hass.states.get(entity_id) is None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -19,6 +19,7 @@ from custom_components.bindhome.const import (
     SERVICE_REMOVE_BINDING,
     SERVICE_REMOVE_RELATION,
     SERVICE_SET_BINDING,
+    SERVICE_UPDATE_ASSET,
 )
 
 
@@ -85,6 +86,42 @@ async def test_create_asset_service_and_area_validation(
             },
             blocking=True,
         )
+
+
+async def test_update_asset_service_is_partial(
+    hass: HomeAssistant,
+    setup_bindhome: MockConfigEntry,
+) -> None:
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_ASSET,
+        {
+            "name": "Original light",
+            "asset_type": "light_point",
+            "code": "LGT-01",
+            "capabilities": ["on_off"],
+        },
+        blocking=True,
+        return_response=True,
+    )
+    asset_id = response["asset"]["id"]
+
+    updated = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_UPDATE_ASSET,
+        {
+            "asset_id": asset_id,
+            "name": "Renamed light",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert updated["asset"]["id"] == asset_id
+    assert updated["asset"]["name"] == "Renamed light"
+    assert updated["asset"]["asset_type"] == "light_point"
+    assert updated["asset"]["code"] == "LGT-01"
+    assert updated["asset"]["capabilities"] == ["on_off"]
 
 
 async def test_create_asset_model_validation_translation(

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -200,9 +200,7 @@ async def test_asset_update_is_partial_and_preserves_unspecified_fields() -> Non
         area_id=None,
         capabilities=["on_off"],
     )
-    assert connection.results == [
-        ("1", {"asset": updated.to_dict()})
-    ]
+    assert connection.results == [("1", {"asset": updated.to_dict()})]
 
 
 @pytest.mark.asyncio

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -47,6 +47,7 @@ class FakeManager:
             "bindings": [],
         }
         self.async_create_asset = AsyncMock()
+        self.async_update_asset = AsyncMock()
         self.async_delete_asset = AsyncMock()
         self.async_add_relation = AsyncMock()
         self.async_remove_relation = AsyncMock()
@@ -150,6 +151,111 @@ async def test_asset_create_rejects_invalid_area() -> None:
 
     assert connection.errors == [("1", "not_found", "missing")]
     manager.async_create_asset.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_asset_update_is_partial_and_preserves_unspecified_fields() -> None:
+    manager = FakeManager()
+    existing = Asset(
+        id="asset-1",
+        name="Old name",
+        asset_type="light_point",
+        code="LGT-01",
+        area_id=None,
+        capabilities=("on_off",),
+    )
+    updated = Asset(
+        id=existing.id,
+        name="New name",
+        asset_type=existing.asset_type,
+        code=existing.code,
+        area_id=existing.area_id,
+        capabilities=existing.capabilities,
+    )
+
+    manager.registry.get_asset.return_value = existing
+    manager.async_update_asset.return_value = updated
+
+    connection = FakeConnection()
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(websocket, "validate_area", Mock())
+
+        await call(
+            websocket.ws_asset_update,
+            hass_for(manager),
+            connection,
+            {
+                "id": "1",
+                "asset_id": existing.id,
+                "name": "New name",
+            },
+        )
+
+    manager.async_update_asset.assert_awaited_once_with(
+        asset_id=existing.id,
+        name="New name",
+        asset_type="light_point",
+        code="LGT-01",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    assert connection.results == [
+        ("1", {"asset": updated.to_dict()})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_asset_update_can_clear_optional_references() -> None:
+    manager = FakeManager()
+    existing = Asset(
+        id="asset-1",
+        name="Light",
+        asset_type="light_point",
+        code="LGT-01",
+        area_id="living_room",
+        capabilities=("on_off",),
+    )
+    updated = Asset(
+        id=existing.id,
+        name=existing.name,
+        asset_type=existing.asset_type,
+        code=None,
+        area_id=None,
+        capabilities=existing.capabilities,
+    )
+
+    manager.registry.get_asset.return_value = existing
+    manager.async_update_asset.return_value = updated
+    connection = FakeConnection()
+    hass = hass_for(manager)
+
+    with pytest.MonkeyPatch.context() as patch:
+        validate = Mock()
+        patch.setattr(websocket, "validate_area", validate)
+
+        await call(
+            websocket.ws_asset_update,
+            hass,
+            connection,
+            {
+                "id": "1",
+                "asset_id": existing.id,
+                "code": None,
+                "area_id": None,
+            },
+        )
+
+    validate.assert_called_once_with(hass, None)
+
+    manager.async_update_asset.assert_awaited_once_with(
+        asset_id=existing.id,
+        name="Light",
+        asset_type="light_point",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
 
 
 @pytest.mark.asyncio
@@ -332,6 +438,7 @@ def test_registers_all_commands_under_bindhome_namespace() -> None:
     assert set(hass.data["websocket_api"]) == {
         websocket.WS_REGISTRY_GET,
         websocket.WS_ASSET_CREATE,
+        websocket.WS_ASSET_UPDATE,
         websocket.WS_ASSET_DELETE,
         websocket.WS_RELATION_CREATE,
         websocket.WS_RELATION_DELETE,


### PR DESCRIPTION
## Summary

- add observable registry mutation notifications
- add full asset updates while preserving stable asset identity
- dynamically reconcile logical light entities at runtime
- preserve logical entity identity across capability removal/re-addition
- propagate asset metadata updates, including `area_id`, to logical entities
- expose partial asset updates through Home Assistant services and WebSocket API
- add runtime reconciliation, service, and WebSocket coverage

## Validation

- 147 tests passing locally
- `ruff check .` passes
- `ruff format --check .` passes
- `git diff --check` passes
- Home Assistant Core 2026.8.3 `check_config` returned valid
- deployed runtime files matched local SHA-256 hashes
- prior runtime lifecycle acceptance verified repeated reload idempotency and stable A→B binding forwarding

## Runtime acceptance — PASSED

Validated on Home Assistant Core 2026.8.3 after one deployment restart. No reloads or restarts were performed during the acceptance sequence:

1. create asset without `on_off` -> no logical light ✅
2. add `on_off` -> logical light appears dynamically ✅
3. logical light enters the HA State Machine ✅
4. partial rename + `area_id` update -> same entity ID, new friendly name, area propagated ✅
5. remove `on_off` -> logical light and state disappear dynamically ✅
6. add `on_off` again -> same entity ID and same unique ID return ✅
7. delete asset -> logical light and state disappear cleanly ✅
8. temporary test asset removed after acceptance ✅

Runtime result: **PASS**

- reloads during acceptance: **0**
- restarts during acceptance: **0**
