### PR TITLE
Add transactional bulk asset creation

### DIFF
--- a/custom_components/bindhome/manager.py
+++ b/custom_components/bindhome/manager.py
@@ -3,15 +3,65 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import SIGNAL_REGISTRY_CHANGED
-from .models import Asset, Binding, Relation
-from .registry import BindHomeRegistry
+from .models import Asset, Binding, ModelValidationError, Relation
+from .registry import (
+    BindHomeRegistry,
+    RegistryError,
+)
 from .resolver import BindingResolver, HomeAssistantEntityProbe
 from .store import BindHomeStore
+
+
+@dataclass(frozen=True, slots=True)
+class AssetCreateSpec:
+    """Validated-boundary input for creating one Asset in a batch."""
+
+    name: str
+    asset_type: str
+    code: str | None = None
+    area_id: str | None = None
+    capabilities: tuple[str, ...] = ()
+
+
+class BulkAssetCreateError(ValueError):
+    """Identify the exact Asset draft that failed during atomic creation."""
+
+    def __init__(
+        self,
+        index: int,
+        cause: Exception,
+        *,
+        field: str | None = None,
+    ) -> None:
+        self.index = index
+        self.cause = cause
+
+        cause_field = getattr(cause, "field", None)
+        if cause_field == "capability":
+            cause_field = "capabilities"
+
+        self.field = field if field is not None else cause_field
+        self.reason = str(cause)
+
+        location = f"assets[{index}]"
+        if self.field is not None:
+            location += f".{self.field}"
+
+        super().__init__(f"{location}: {self.reason}")
+
+    def to_dict(self) -> dict[str, object]:
+        """Return structured details suitable for a user-facing API."""
+        return {
+            "index": self.index,
+            "field": self.field,
+            "message": self.reason,
+        }
 
 
 class BindHomeManager:
@@ -33,6 +83,22 @@ class BindHomeManager:
         """Persist the registry and notify runtime consumers."""
         await self._store.async_save(self.registry)
         async_dispatcher_send(self.hass, SIGNAL_REGISTRY_CHANGED)
+
+    def _adopt_staged_registry(self, staged: BindHomeRegistry) -> None:
+        """Commit staged state while preserving the live registry identity.
+
+        Long-lived runtime consumers may retain references to the current
+        BindHomeRegistry, so batch commits replace its contents rather than
+        replacing the registry object itself.
+        """
+        self.registry.assets.clear()
+        self.registry.assets.update(staged.assets)
+
+        self.registry.relations.clear()
+        self.registry.relations.update(staged.relations)
+
+        self.registry.bindings.clear()
+        self.registry.bindings.update(staged.bindings)
 
     async def async_load(self) -> None:
         """Load persisted registry state."""
@@ -60,6 +126,43 @@ class BindHomeManager:
             )
             await self._async_persist_and_notify()
             return asset
+
+    async def async_create_assets(
+        self,
+        specs: list[AssetCreateSpec],
+    ) -> list[Asset]:
+        """Create many Assets as one atomic persistent mutation."""
+        if not specs:
+            raise ValueError("assets must contain at least one item")
+
+        async with self._mutation_lock:
+            staged = BindHomeRegistry.from_dict(self.registry.to_dict())
+            created: list[Asset] = []
+
+            for index, spec in enumerate(specs):
+                try:
+                    asset = Asset.create(
+                        name=spec.name,
+                        asset_type=spec.asset_type,
+                        code=spec.code,
+                        area_id=spec.area_id,
+                        capabilities=list(spec.capabilities),
+                    )
+                    staged.add_asset(asset)
+                except (ModelValidationError, RegistryError) as err:
+                    raise BulkAssetCreateError(index, err) from err
+
+                created.append(asset)
+
+            # Persistence is deliberately performed before changing the live
+            # registry. If storage fails, the running registry remains exactly
+            # as it was before the batch.
+            await self._store.async_save(staged)
+
+            self._adopt_staged_registry(staged)
+            async_dispatcher_send(self.hass, SIGNAL_REGISTRY_CHANGED)
+
+            return created
 
     async def async_update_asset(
         self,

--- a/custom_components/bindhome/models.py
+++ b/custom_components/bindhome/models.py
@@ -13,13 +13,23 @@ _IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 class ModelValidationError(ValueError):
     """Raised when a BindHome model is invalid."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        field: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.field = field
+
 
 def normalize_identifier(value: str, field: str) -> str:
     """Validate and normalize an extensible identifier."""
     normalized = value.strip().lower()
     if not _IDENTIFIER_RE.fullmatch(normalized):
         raise ModelValidationError(
-            f"{field} must use lower_snake_case and start with a letter"
+            f"{field} must use lower_snake_case and start with a letter",
+            field=field,
         )
     return normalized
 
@@ -28,7 +38,10 @@ def normalize_non_empty(value: str, field: str) -> str:
     """Return a trimmed non-empty string."""
     normalized = value.strip()
     if not normalized:
-        raise ModelValidationError(f"{field} must not be empty")
+        raise ModelValidationError(
+            f"{field} must not be empty",
+            field=field,
+        )
     return normalized
 
 
@@ -140,13 +153,17 @@ class Asset:
             asset_type = normalize_identifier(str(data["asset_type"]), "asset_type")
         except KeyError as err:
             raise ModelValidationError(
-                f"Missing required asset field: {err.args[0]}"
+                f"Missing required asset field: {err.args[0]}",
+                field=str(err.args[0]),
             ) from err
         code_raw = data.get("code")
         area_raw = data.get("area_id")
         capabilities_raw = data.get("capabilities", [])
         if not isinstance(capabilities_raw, (list, tuple)):
-            raise ModelValidationError("Capabilities must be a list or tuple")
+            raise ModelValidationError(
+                "Capabilities must be a list or tuple",
+                field="capabilities",
+            )
         capabilities = tuple(
             sorted(
                 {

--- a/custom_components/bindhome/registry.py
+++ b/custom_components/bindhome/registry.py
@@ -12,6 +12,15 @@ from .models import Asset, Binding, ModelValidationError, Relation
 class RegistryError(ValueError):
     """Base registry error."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        field: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.field = field
+
 
 class RegistryNotFoundError(RegistryError):
     """Raised when a registry object does not exist."""
@@ -40,7 +49,10 @@ class BindHomeRegistry:
         if asset.code and any(
             existing.code == asset.code for existing in self.assets.values()
         ):
-            raise RegistryConflictError(f"Asset code {asset.code} already exists")
+            raise RegistryConflictError(
+                f"Asset code {asset.code} already exists",
+                field="code",
+            )
         self.assets[asset.id] = asset
         return asset
 
@@ -68,7 +80,10 @@ class BindHomeRegistry:
             existing.id != asset_id and existing.code == updated.code
             for existing in self.assets.values()
         ):
-            raise RegistryConflictError(f"Asset code {updated.code} already exists")
+            raise RegistryConflictError(
+                f"Asset code {updated.code} already exists",
+                field="code",
+            )
 
         removed = set(asset.capabilities) - set(updated.capabilities)
         if removed:

--- a/custom_components/bindhome/websocket.py
+++ b/custom_components/bindhome/websocket.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, cast
 
 import voluptuous as vol
@@ -23,7 +24,11 @@ from homeassistant.helpers import config_validation as cv
 
 from . import query
 from .const import DOMAIN
-from .manager import BindHomeManager
+from .manager import (
+    AssetCreateSpec,
+    BindHomeManager,
+    BulkAssetCreateError,
+)
 from .models import ModelValidationError
 from .query import Direction
 from .registry import (
@@ -36,6 +41,7 @@ from .validation import validate_area, validate_entity
 
 WS_REGISTRY_GET = f"{DOMAIN}/registry/get"
 WS_ASSET_CREATE = f"{DOMAIN}/assets/create"
+WS_ASSET_CREATE_BULK = f"{DOMAIN}/assets/create_bulk"
 WS_ASSET_UPDATE = f"{DOMAIN}/assets/update"
 WS_ASSET_DELETE = f"{DOMAIN}/assets/delete"
 WS_RELATION_CREATE = f"{DOMAIN}/relations/create"
@@ -50,6 +56,16 @@ WS_GRAPH_PATH = f"{DOMAIN}/graph/path"
 WS_BINDING_STATUS = f"{DOMAIN}/bindings/status"
 
 _DIRECTIONS = [direction.value for direction in Direction]
+
+_ASSET_CREATE_ITEM_SCHEMA = vol.Schema(
+    {
+        vol.Required("name"): cv.string,
+        vol.Required("asset_type"): cv.string,
+        vol.Optional("code"): cv.string,
+        vol.Optional("area_id"): cv.string,
+        vol.Optional("capabilities", default=[]): [cv.string],
+    }
+)
 
 
 def _get_manager(hass: HomeAssistant) -> BindHomeManager:
@@ -79,6 +95,26 @@ def _send_error(
     else:
         code = ERR_INVALID_FORMAT
     connection.send_error(msg["id"], code, str(err))
+
+
+def _send_bulk_asset_error(
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    err: BulkAssetCreateError,
+) -> None:
+    """Return an indexed, machine-readable error for one batch item."""
+    if isinstance(err.cause, RegistryConflictError):
+        code = "conflict"
+    elif isinstance(err.cause, ServiceValidationError):
+        code = ERR_NOT_FOUND
+    else:
+        code = ERR_INVALID_FORMAT
+
+    connection.send_error(
+        msg["id"],
+        code,
+        json.dumps(err.to_dict(), separators=(",", ":")),
+    )
 
 
 @require_admin
@@ -125,6 +161,58 @@ async def ws_asset_create(
         _send_error(connection, msg, err)
         return
     connection.send_result(msg["id"], {"asset": asset.to_dict()})
+
+
+@require_admin
+@websocket_command(
+    {
+        vol.Required("type"): WS_ASSET_CREATE_BULK,
+        vol.Required("assets"): vol.All(
+            [_ASSET_CREATE_ITEM_SCHEMA],
+            vol.Length(min=1),
+        ),
+    }
+)
+@async_response
+async def ws_asset_create_bulk(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Create multiple Assets as one atomic mutation."""
+    specs: list[AssetCreateSpec] = []
+
+    for index, raw in enumerate(msg["assets"]):
+        try:
+            validate_area(hass, raw.get("area_id"))
+        except ServiceValidationError as err:
+            _send_bulk_asset_error(
+                connection,
+                msg,
+                BulkAssetCreateError(index, err, field="area_id"),
+            )
+            return
+
+        specs.append(
+            AssetCreateSpec(
+                name=raw["name"],
+                asset_type=raw["asset_type"],
+                code=raw.get("code"),
+                area_id=raw.get("area_id"),
+                capabilities=tuple(raw.get("capabilities", [])),
+            )
+        )
+
+    try:
+        assets = await _get_manager(hass).async_create_assets(specs)
+    except BulkAssetCreateError as err:
+        _send_bulk_asset_error(connection, msg, err)
+        return
+
+    connection.send_result(
+        msg["id"],
+        {"assets": [asset.to_dict() for asset in assets]},
+    )
 
 
 @require_admin
@@ -436,6 +524,7 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     for handler in (
         ws_registry_get,
         ws_asset_create,
+        ws_asset_create_bulk,
         ws_asset_update,
         ws_asset_delete,
         ws_relation_create,

--- a/tests/test_bulk_assets.py
+++ b/tests/test_bulk_assets.py
@@ -1,0 +1,294 @@
+"""Tests for transactional bulk Asset creation."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from custom_components.bindhome.const import SIGNAL_REGISTRY_CHANGED
+from custom_components.bindhome.manager import (
+    AssetCreateSpec,
+    BindHomeManager,
+    BulkAssetCreateError,
+)
+from custom_components.bindhome.resolver import ResolutionStatus
+
+
+async def test_bulk_create_persists_once_preserves_order_and_registry_identity(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+
+    original_registry = manager.registry
+
+    notifications: list[None] = []
+    unsubscribe = async_dispatcher_connect(
+        hass,
+        SIGNAL_REGISTRY_CHANGED,
+        lambda: notifications.append(None),
+    )
+
+    real_save = manager._store.async_save
+    manager._store.async_save = AsyncMock(wraps=real_save)
+
+    created = await manager.async_create_assets(
+        [
+            AssetCreateSpec(
+                name="Light point 1",
+                asset_type="light_point",
+                area_id="living_room",
+                capabilities=("on_off",),
+            ),
+            AssetCreateSpec(
+                name="Socket 1",
+                asset_type="socket",
+                code="SOCK-01",
+                area_id="living_room",
+            ),
+            AssetCreateSpec(
+                name="Radiator 1",
+                asset_type="radiator",
+                area_id="living_room",
+            ),
+        ]
+    )
+    await hass.async_block_till_done()
+
+    assert [asset.name for asset in created] == [
+        "Light point 1",
+        "Socket 1",
+        "Radiator 1",
+    ]
+
+    # Long-lived runtime consumers may retain this object.
+    assert manager.registry is original_registry
+
+    assert manager._store.async_save.await_count == 1
+    assert notifications == [None]
+
+    assert list(manager.registry.assets) == [asset.id for asset in created]
+
+    # Verify the one persisted batch can be reloaded normally.
+    reloaded = BindHomeManager(hass)
+    await reloaded.async_load()
+
+    assert [asset.name for asset in reloaded.registry.assets.values()] == [
+        "Light point 1",
+        "Socket 1",
+        "Radiator 1",
+    ]
+
+    unsubscribe()
+
+
+async def test_bulk_create_duplicate_code_rolls_back_entire_batch(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+
+    notifications: list[None] = []
+    unsubscribe = async_dispatcher_connect(
+        hass,
+        SIGNAL_REGISTRY_CHANGED,
+        lambda: notifications.append(None),
+    )
+
+    manager._store.async_save = AsyncMock()
+
+    with pytest.raises(BulkAssetCreateError) as raised:
+        await manager.async_create_assets(
+            [
+                AssetCreateSpec(
+                    name="Socket 1",
+                    asset_type="socket",
+                    code="SOCK-01",
+                ),
+                AssetCreateSpec(
+                    name="Socket 2",
+                    asset_type="socket",
+                    code="SOCK-01",
+                ),
+                AssetCreateSpec(
+                    name="Socket 3",
+                    asset_type="socket",
+                    code="SOCK-03",
+                ),
+            ]
+        )
+
+    error = raised.value
+
+    assert error.index == 1
+    assert error.field == "code"
+    assert "SOCK-01" in error.reason
+
+    assert manager.registry.assets == {}
+    manager._store.async_save.assert_not_awaited()
+
+    await hass.async_block_till_done()
+    assert notifications == []
+
+    unsubscribe()
+
+
+async def test_bulk_create_model_error_identifies_failing_row(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+
+    manager._store.async_save = AsyncMock()
+
+    with pytest.raises(BulkAssetCreateError) as raised:
+        await manager.async_create_assets(
+            [
+                AssetCreateSpec(
+                    name="Socket 1",
+                    asset_type="socket",
+                ),
+                AssetCreateSpec(
+                    name="Broken",
+                    asset_type="Not Valid",
+                ),
+                AssetCreateSpec(
+                    name="Socket 3",
+                    asset_type="socket",
+                ),
+            ]
+        )
+
+    error = raised.value
+
+    assert error.index == 1
+    assert error.field == "asset_type"
+    assert manager.registry.assets == {}
+    manager._store.async_save.assert_not_awaited()
+
+
+async def test_bulk_create_storage_failure_leaves_live_registry_unchanged(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+
+    existing = await manager.async_create_asset(
+        name="Existing socket",
+        asset_type="socket",
+        code="EXISTING-01",
+        area_id=None,
+        capabilities=[],
+    )
+
+    original_registry = manager.registry
+    original_assets = dict(manager.registry.assets)
+
+    manager._store.async_save = AsyncMock(
+        side_effect=RuntimeError("storage failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="storage failed"):
+        await manager.async_create_assets(
+            [
+                AssetCreateSpec(
+                    name="New socket",
+                    asset_type="socket",
+                    code="NEW-01",
+                )
+            ]
+        )
+
+    assert manager.registry is original_registry
+    assert manager.registry.assets == original_assets
+    assert list(manager.registry.assets) == [existing.id]
+
+
+async def test_bulk_create_rejects_empty_batch(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+
+    manager._store.async_save = AsyncMock()
+
+    with pytest.raises(
+        ValueError,
+        match="assets must contain at least one item",
+    ):
+        await manager.async_create_assets([])
+
+    manager._store.async_save.assert_not_awaited()
+
+
+async def test_bulk_create_preserves_existing_topology_bindings_and_live_resolver(
+    hass: HomeAssistant,
+) -> None:
+    """A batch commit must not invalidate existing runtime references."""
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+
+    source = await manager.async_create_asset(
+        name="Panel",
+        asset_type="panel",
+        code="PANEL-01",
+        area_id=None,
+        capabilities=[],
+    )
+    target = await manager.async_create_asset(
+        name="Existing light",
+        asset_type="light_point",
+        code="LGT-01",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+
+    relation = await manager.async_add_relation(
+        source_asset_id=source.id,
+        relation_type="feeds",
+        target_asset_id=target.id,
+    )
+
+    binding = await manager.async_set_binding(
+        asset_id=target.id,
+        capability="on_off",
+        entity_id="switch.existing_backend",
+        role="primary",
+    )
+
+    # Capture a resolver before the batch. This is representative of a
+    # long-lived logical entity which must keep observing the live registry.
+    resolver = manager.resolver
+    original_registry = manager.registry
+
+    manager._store.async_save = AsyncMock()
+
+    created = await manager.async_create_assets(
+        [
+            AssetCreateSpec(
+                name="New logical candidate",
+                asset_type="light_point",
+                code="LGT-02",
+                capabilities=("on_off",),
+            )
+        ]
+    )
+
+    new_asset = created[0]
+
+    assert manager.registry is original_registry
+
+    # Existing topology and bindings survive the staged commit unchanged.
+    assert manager.registry.relations[relation.id] == relation
+    assert manager.registry.bindings[binding.id] == binding
+
+    # Most importantly, the resolver created BEFORE the batch sees the newly
+    # committed Asset. If the manager had replaced the registry object, this
+    # would incorrectly return ASSET_NOT_FOUND.
+    resolution = resolver.resolve(new_asset.id, "on_off")
+
+    assert resolution.status is ResolutionStatus.BINDING_NOT_FOUND
+    assert resolution.config_valid is False
+
+    manager._store.async_save.assert_awaited_once()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -47,6 +47,7 @@ class FakeManager:
             "bindings": [],
         }
         self.async_create_asset = AsyncMock()
+        self.async_create_assets = AsyncMock()
         self.async_update_asset = AsyncMock()
         self.async_delete_asset = AsyncMock()
         self.async_add_relation = AsyncMock()
@@ -151,6 +152,178 @@ async def test_asset_create_rejects_invalid_area() -> None:
 
     assert connection.errors == [("1", "not_found", "missing")]
     manager.async_create_asset.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_asset_create_bulk_returns_assets_in_request_order() -> None:
+    manager = FakeManager()
+
+    first = Asset.create(
+        name="Light point 1",
+        asset_type="light_point",
+        area_id="living_room",
+    )
+    second = Asset.create(
+        name="Socket 1",
+        asset_type="socket",
+        area_id="living_room",
+    )
+
+    manager.async_create_assets.return_value = [first, second]
+
+    connection = FakeConnection()
+    hass = hass_for(manager)
+
+    with pytest.MonkeyPatch.context() as patch:
+        validate = Mock()
+        patch.setattr(websocket, "validate_area", validate)
+
+        await call(
+            websocket.ws_asset_create_bulk,
+            hass,
+            connection,
+            {
+                "id": "1",
+                "assets": [
+                    {
+                        "name": "Light point 1",
+                        "asset_type": "light_point",
+                        "area_id": "living_room",
+                    },
+                    {
+                        "name": "Socket 1",
+                        "asset_type": "socket",
+                        "area_id": "living_room",
+                    },
+                ],
+            },
+        )
+
+    specs = manager.async_create_assets.await_args.args[0]
+
+    assert [spec.name for spec in specs] == [
+        "Light point 1",
+        "Socket 1",
+    ]
+    assert [spec.area_id for spec in specs] == [
+        "living_room",
+        "living_room",
+    ]
+
+    assert validate.call_count == 2
+
+    assert connection.results == [
+        (
+            "1",
+            {
+                "assets": [
+                    first.to_dict(),
+                    second.to_dict(),
+                ]
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_asset_create_bulk_identifies_invalid_area_row() -> None:
+    manager = FakeManager()
+    connection = FakeConnection()
+    hass = hass_for(manager)
+
+    def validate(_hass, area_id):
+        if area_id == "missing":
+            raise websocket.ServiceValidationError("Area missing")
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(websocket, "validate_area", validate)
+
+        await call(
+            websocket.ws_asset_create_bulk,
+            hass,
+            connection,
+            {
+                "id": "1",
+                "assets": [
+                    {
+                        "name": "Socket 1",
+                        "asset_type": "socket",
+                        "area_id": "living_room",
+                    },
+                    {
+                        "name": "Socket 2",
+                        "asset_type": "socket",
+                        "area_id": "missing",
+                    },
+                ],
+            },
+        )
+
+    assert manager.async_create_assets.await_count == 0
+    assert len(connection.errors) == 1
+
+    message_id, code, raw_error = connection.errors[0]
+    details = json.loads(raw_error)
+
+    assert message_id == "1"
+    assert code == "not_found"
+    assert details == {
+        "index": 1,
+        "field": "area_id",
+        "message": "Area missing",
+    }
+
+
+@pytest.mark.asyncio
+async def test_asset_create_bulk_returns_structured_conflict_row() -> None:
+    manager = FakeManager()
+    manager.async_create_assets.side_effect = websocket.BulkAssetCreateError(
+        1,
+        RegistryConflictError(
+            "Asset code SOCK-01 already exists",
+            field="code",
+        ),
+    )
+
+    connection = FakeConnection()
+    hass = hass_for(manager)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(websocket, "validate_area", Mock())
+
+        await call(
+            websocket.ws_asset_create_bulk,
+            hass,
+            connection,
+            {
+                "id": "1",
+                "assets": [
+                    {
+                        "name": "Socket 1",
+                        "asset_type": "socket",
+                        "code": "SOCK-01",
+                    },
+                    {
+                        "name": "Socket 2",
+                        "asset_type": "socket",
+                        "code": "SOCK-01",
+                    },
+                ],
+            },
+        )
+
+    assert len(connection.errors) == 1
+
+    message_id, code, raw_error = connection.errors[0]
+    details = json.loads(raw_error)
+
+    assert message_id == "1"
+    assert code == "conflict"
+    assert details == {
+        "index": 1,
+        "field": "code",
+        "message": "Asset code SOCK-01 already exists",
+    }
 
 
 @pytest.mark.asyncio
@@ -428,6 +601,15 @@ def test_command_schemas_reject_malformed_payloads() -> None:
             {"id": "1", "type": websocket.WS_ASSET_CREATE}
         )
 
+    with pytest.raises(vol.Invalid):
+        websocket.ws_asset_create_bulk._ws_schema(
+            {
+                "id": "2",
+                "type": websocket.WS_ASSET_CREATE_BULK,
+                "assets": [],
+            }
+        )
+
 
 def test_registers_all_commands_under_bindhome_namespace() -> None:
     hass = SimpleNamespace(data={})
@@ -436,6 +618,7 @@ def test_registers_all_commands_under_bindhome_namespace() -> None:
     assert set(hass.data["websocket_api"]) == {
         websocket.WS_REGISTRY_GET,
         websocket.WS_ASSET_CREATE,
+        websocket.WS_ASSET_CREATE_BULK,
         websocket.WS_ASSET_UPDATE,
         websocket.WS_ASSET_DELETE,
         websocket.WS_RELATION_CREATE,


### PR DESCRIPTION
## Summary

- add atomic `1..N` Asset creation through the BindHome manager
- add `bindhome/assets/create_bulk` to the WebSocket API for the future inventory UX
- validate Home Assistant Area references before batch mutation
- preserve request order in successful responses
- return indexed row errors with `index`, `field`, and `message`
- make model and registry validation errors carry structured field metadata instead of parsing exception text
- persist the staged registry once and emit one registry-changed notification
- preserve the identity of the live registry object so existing resolvers and runtime consumers remain valid
- roll back the entire batch on model validation errors, registry conflicts, or storage failures
- preserve existing Assets, relations, and bindings across batch commits

## Architecture

This implements P0-A from the inventory-first product contract. It deliberately does not add Representation or creation presets yet.

Home Assistant remains authoritative for Areas and other HA infrastructure. BindHome validates Area references against HA and stores only the Area ID reference.

The bulk operation is exposed through WebSocket only; no duplicate Home Assistant service is added because this primitive exists specifically to support the BindHome UI workflow.

## Validation

Local validation on commit `ec2f5e3`:

- `ruff check .` — PASS
- `ruff format --check .` — PASS
- `git diff --check` — PASS
- targeted bulk/WebSocket tests — PASS
- full suite — `153 passed`

Coverage includes:

- single persistence for a successful batch
- single registry notification
- deterministic response order
- duplicate-code rollback
- model-validation rollback
- storage-failure rollback
- empty-batch rejection
- indexed invalid-Area errors
- structured conflict errors
- preservation of live registry identity
- preservation of existing topology and bindings
- pre-existing resolver remains attached to the updated live registry

## Next

After merge, P0-B will introduce the explicit optional Representation model so Asset capabilities no longer implicitly determine logical Home Assistant entity type.