### PR TITLE
Add explicit asset representations

### DIFF
--- a/custom_components/bindhome/__init__.py
+++ b/custom_components/bindhome/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN
+from .const import DOMAIN, REPRESENTATION_REQUIREMENTS
 from .manager import BindHomeManager
 from .panel import async_register_panel, async_unregister_panel
 from .services import async_register_services
@@ -17,7 +17,7 @@ from .websocket import async_register_websocket_commands
 type BindHomeConfigEntry = ConfigEntry[BindHomeManager]
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-PLATFORMS = [Platform.LIGHT]
+PLATFORMS = [Platform(platform) for platform in REPRESENTATION_REQUIREMENTS]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/bindhome/const.py
+++ b/custom_components/bindhome/const.py
@@ -11,6 +11,15 @@ REGISTRY_SCHEMA_VERSION: Final = 1
 
 SIGNAL_REGISTRY_CHANGED: Final = f"{DOMAIN}_registry_changed"
 
+# BindHome-owned logical representation contracts.
+#
+# This is deliberately NOT a Home Assistant domain catalogue. It lists only
+# logical entity platforms implemented by BindHome itself and the BindHome
+# capabilities each implementation requires.
+REPRESENTATION_REQUIREMENTS: Final[dict[str, frozenset[str]]] = {
+    "light": frozenset({"on_off"}),
+}
+
 SERVICE_CREATE_ASSET: Final = "create_asset"
 SERVICE_UPDATE_ASSET: Final = "update_asset"
 SERVICE_DELETE_ASSET: Final = "delete_asset"

--- a/custom_components/bindhome/light.py
+++ b/custom_components/bindhome/light.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN, SIGNAL_REGISTRY_CHANGED
 from .manager import BindHomeManager
-from .models import Asset
+from .models import Asset, Representation
 from .resolver import (
     BindingResolver,
     Resolution,
@@ -38,16 +38,20 @@ async def async_setup_entry(
     async def async_reconcile() -> None:
         """Reconcile logical lights against the current BindHome registry."""
         async with reconcile_lock:
-            eligible_assets = {
-                asset.id: asset
-                for asset in manager.registry.assets.values()
-                if BindHomeLight.is_eligible(asset)
-            }
+            eligible_assets: dict[str, Asset] = {}
+
+            for asset_id, representation in manager.registry.representations.items():
+                if representation.platform != "light":
+                    continue
+
+                asset = manager.registry.get_asset(asset_id)
+                if BindHomeLight.is_eligible(asset, representation):
+                    eligible_assets[asset.id] = asset
 
             current_ids = set(entities)
             eligible_ids = set(eligible_assets)
 
-            # Remove logical entities whose assets no longer expose on_off.
+            # Remove logical entities whose light Representation disappeared.
             for asset_id in sorted(current_ids - eligible_ids):
                 entity = entities.pop(asset_id)
 
@@ -154,9 +158,16 @@ class BindHomeLight(LightEntity):
             self.async_write_ha_state()
 
     @staticmethod
-    def is_eligible(asset: Asset) -> bool:
-        """Return whether an asset can be represented as a logical light."""
-        return _CAPABILITY in asset.capabilities
+    def is_eligible(
+        asset: Asset,
+        representation: Representation,
+    ) -> bool:
+        """Return whether this explicit Representation belongs to this light."""
+        return (
+            representation.asset_id == asset.id
+            and representation.platform == "light"
+            and _CAPABILITY in asset.capabilities
+        )
 
     async def async_update(self) -> None:
         """Refresh state from the binding resolved at operation time."""

--- a/custom_components/bindhome/manager.py
+++ b/custom_components/bindhome/manager.py
@@ -9,7 +9,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import SIGNAL_REGISTRY_CHANGED
-from .models import Asset, Binding, ModelValidationError, Relation
+from .models import (
+    Asset,
+    Binding,
+    ModelValidationError,
+    Relation,
+    Representation,
+)
 from .registry import (
     BindHomeRegistry,
     RegistryError,
@@ -99,6 +105,9 @@ class BindHomeManager:
 
         self.registry.bindings.clear()
         self.registry.bindings.update(staged.bindings)
+
+        self.registry.representations.clear()
+        self.registry.representations.update(staged.representations)
 
     async def async_load(self) -> None:
         """Load persisted registry state."""
@@ -239,4 +248,27 @@ class BindHomeManager:
         """Remove and persist a binding."""
         async with self._mutation_lock:
             self.registry.remove_binding(binding_id)
+            await self._async_persist_and_notify()
+
+    async def async_set_representation(
+        self,
+        *,
+        asset_id: str,
+        platform: str,
+    ) -> Representation:
+        """Create and persist an Asset's logical representation."""
+        async with self._mutation_lock:
+            representation = self.registry.set_representation(
+                Representation.create(
+                    asset_id=asset_id,
+                    platform=platform,
+                )
+            )
+            await self._async_persist_and_notify()
+            return representation
+
+    async def async_remove_representation(self, asset_id: str) -> None:
+        """Remove and persist an Asset's logical representation."""
+        async with self._mutation_lock:
+            self.registry.remove_representation(asset_id)
             await self._async_persist_and_notify()

--- a/custom_components/bindhome/models.py
+++ b/custom_components/bindhome/models.py
@@ -191,6 +191,57 @@ class Asset:
 
 
 @dataclass(frozen=True, slots=True)
+class Representation:
+    """Describe how BindHome exposes an Asset back into Home Assistant."""
+
+    asset_id: str
+    platform: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        asset_id: str,
+        platform: str,
+    ) -> Representation:
+        """Create a normalized logical representation."""
+        return cls(
+            asset_id=normalize_non_empty(asset_id, "asset_id"),
+            platform=normalize_identifier(platform, "platform"),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize the representation."""
+        return {
+            "asset_id": self.asset_id,
+            "platform": self.platform,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Representation:
+        """Deserialize and validate a representation."""
+        if not isinstance(data, dict):
+            raise ModelValidationError("Representation data must be a dictionary")
+
+        try:
+            return cls(
+                asset_id=normalize_non_empty(
+                    str(data["asset_id"]),
+                    "asset_id",
+                ),
+                platform=normalize_identifier(
+                    str(data["platform"]),
+                    "platform",
+                ),
+            )
+        except KeyError as err:
+            raise ModelValidationError(
+                f"Missing required representation field: {err.args[0]}",
+                field=str(err.args[0]),
+            ) from err
+
+
+@dataclass(frozen=True, slots=True)
 class Relation:
     """A directed topology relation between two assets."""
 

--- a/custom_components/bindhome/registry.py
+++ b/custom_components/bindhome/registry.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 from dataclasses import replace
 from typing import Any
 
-from .const import REGISTRY_SCHEMA_VERSION
-from .models import Asset, Binding, ModelValidationError, Relation
+from .const import REGISTRY_SCHEMA_VERSION, REPRESENTATION_REQUIREMENTS
+from .models import (
+    Asset,
+    Binding,
+    ModelValidationError,
+    Relation,
+    Representation,
+)
 
 
 class RegistryError(ValueError):
@@ -35,12 +41,13 @@ class RegistryValidationError(RegistryError):
 
 
 class BindHomeRegistry:
-    """Store assets, topology relations, and capability bindings."""
+    """Store BindHome-owned infrastructure abstractions."""
 
     def __init__(self) -> None:
         self.assets: dict[str, Asset] = {}
         self.relations: dict[str, Relation] = {}
         self.bindings: dict[str, Binding] = {}
+        self.representations: dict[str, Representation] = {}
 
     def add_asset(self, asset: Asset) -> Asset:
         """Add an asset."""
@@ -97,6 +104,18 @@ class BindHomeRegistry:
                     "Cannot remove capabilities that still have active bindings"
                 )
 
+            representation = self.representations.get(asset_id)
+            if representation is not None:
+                required = REPRESENTATION_REQUIREMENTS[representation.platform]
+                missing = sorted(required - set(updated.capabilities))
+                if missing:
+                    raise RegistryConflictError(
+                        "Cannot remove capabilities required by active "
+                        f"{representation.platform} representation: "
+                        f"{', '.join(missing)}",
+                        field="capabilities",
+                    )
+
         self.assets[asset_id] = updated
         return updated
 
@@ -124,6 +143,10 @@ class BindHomeRegistry:
             raise RegistryConflictError("Cannot delete an asset used by a relation")
         if any(binding.asset_id == asset_id for binding in self.bindings.values()):
             raise RegistryConflictError("Cannot delete an asset with active bindings")
+        if asset_id in self.representations:
+            raise RegistryConflictError(
+                "Cannot delete an asset with active representation"
+            )
         del self.assets[asset_id]
 
     def get_asset(self, asset_id: str) -> Asset:
@@ -209,6 +232,59 @@ class BindHomeRegistry:
             raise RegistryNotFoundError(f"Binding {binding_id} was not found")
         del self.bindings[binding_id]
 
+    def set_representation(
+        self,
+        representation: Representation,
+    ) -> Representation:
+        """Create the optional logical representation for an Asset."""
+        asset = self.get_asset(representation.asset_id)
+
+        required = REPRESENTATION_REQUIREMENTS.get(representation.platform)
+        if required is None:
+            raise RegistryValidationError(
+                "BindHome does not implement representation platform "
+                f"{representation.platform}",
+                field="platform",
+            )
+
+        missing = sorted(required - set(asset.capabilities))
+        if missing:
+            raise RegistryValidationError(
+                f"{representation.platform} representation requires capabilities: "
+                f"{', '.join(missing)}",
+                field="capabilities",
+            )
+
+        existing = self.representations.get(asset.id)
+        if existing is not None:
+            if existing.platform == representation.platform:
+                return existing
+
+            raise RegistryConflictError(
+                "Cannot change representation platform directly; "
+                "remove the current representation first",
+                field="platform",
+            )
+
+        self.representations[asset.id] = representation
+        return representation
+
+    def get_representation(self, asset_id: str) -> Representation | None:
+        """Return an Asset's logical representation, if configured."""
+        self.get_asset(asset_id)
+        return self.representations.get(asset_id)
+
+    def remove_representation(self, asset_id: str) -> None:
+        """Remove an Asset's logical representation."""
+        self.get_asset(asset_id)
+
+        if asset_id not in self.representations:
+            raise RegistryNotFoundError(
+                f"Representation for Asset {asset_id} was not found"
+            )
+
+        del self.representations[asset_id]
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize the complete registry."""
         return {
@@ -216,6 +292,10 @@ class BindHomeRegistry:
             "assets": [asset.to_dict() for asset in self.assets.values()],
             "relations": [relation.to_dict() for relation in self.relations.values()],
             "bindings": [binding.to_dict() for binding in self.bindings.values()],
+            "representations": [
+                representation.to_dict()
+                for representation in self.representations.values()
+            ],
         }
 
     @classmethod
@@ -232,6 +312,12 @@ class BindHomeRegistry:
             raise RegistryValidationError(
                 f"Unsupported registry schema version: {schema_version}"
             )
+
+        # Persisted registries created before Representation existed have no
+        # "representations" key. Preserve their exact previous runtime
+        # behaviour once by migrating every formerly implicit on_off logical
+        # light to an explicit light Representation.
+        legacy_implicit_representations = "representations" not in data
 
         for raw_asset in data.get("assets", []):
             try:
@@ -256,5 +342,27 @@ class BindHomeRegistry:
                 raise RegistryValidationError(
                     f"Invalid binding in registry: {err}"
                 ) from err
+
+        if legacy_implicit_representations:
+            for asset in registry.assets.values():
+                if "on_off" not in asset.capabilities:
+                    continue
+
+                registry.set_representation(
+                    Representation.create(
+                        asset_id=asset.id,
+                        platform="light",
+                    )
+                )
+        else:
+            for raw_representation in data.get("representations", []):
+                try:
+                    registry.set_representation(
+                        Representation.from_dict(raw_representation)
+                    )
+                except (ModelValidationError, RegistryError) as err:
+                    raise RegistryValidationError(
+                        f"Invalid representation in registry: {err}"
+                    ) from err
 
         return registry

--- a/custom_components/bindhome/system_health.py
+++ b/custom_components/bindhome/system_health.py
@@ -36,4 +36,5 @@ async def _async_system_health_info(hass: HomeAssistant) -> dict[str, Any]:
         "assets": len(manager.registry.assets),
         "relations": len(manager.registry.relations),
         "bindings": len(manager.registry.bindings),
+        "representations": len(manager.registry.representations),
     }

--- a/custom_components/bindhome/websocket.py
+++ b/custom_components/bindhome/websocket.py
@@ -48,6 +48,8 @@ WS_RELATION_CREATE = f"{DOMAIN}/relations/create"
 WS_RELATION_DELETE = f"{DOMAIN}/relations/delete"
 WS_BINDING_SET = f"{DOMAIN}/bindings/set"
 WS_BINDING_DELETE = f"{DOMAIN}/bindings/delete"
+WS_REPRESENTATION_SET = f"{DOMAIN}/representations/set"
+WS_REPRESENTATION_DELETE = f"{DOMAIN}/representations/delete"
 WS_ASSET_GET = f"{DOMAIN}/assets/get"
 WS_ASSET_LIST = f"{DOMAIN}/assets/list"
 WS_RELATION_LIST = f"{DOMAIN}/relations/list"
@@ -368,6 +370,59 @@ async def ws_binding_delete(
 
 @require_admin
 @websocket_command(
+    {
+        vol.Required("type"): WS_REPRESENTATION_SET,
+        vol.Required("asset_id"): cv.string,
+        vol.Required("platform"): cv.string,
+    }
+)
+@async_response
+async def ws_representation_set(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Create an Asset's logical Home Assistant representation."""
+    try:
+        representation = await _get_manager(hass).async_set_representation(
+            asset_id=msg["asset_id"],
+            platform=msg["platform"],
+        )
+    except (ModelValidationError, RegistryError) as err:
+        _send_error(connection, msg, err)
+        return
+
+    connection.send_result(
+        msg["id"],
+        {"representation": representation.to_dict()},
+    )
+
+
+@require_admin
+@websocket_command(
+    {
+        vol.Required("type"): WS_REPRESENTATION_DELETE,
+        vol.Required("asset_id"): cv.string,
+    }
+)
+@async_response
+async def ws_representation_delete(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Remove an Asset's logical Home Assistant representation."""
+    try:
+        await _get_manager(hass).async_remove_representation(msg["asset_id"])
+    except RegistryError as err:
+        _send_error(connection, msg, err)
+        return
+
+    connection.send_result(msg["id"], {"deleted": True})
+
+
+@require_admin
+@websocket_command(
     {vol.Required("type"): WS_ASSET_GET, vol.Required("asset_id"): cv.string}
 )
 @async_response
@@ -531,6 +586,8 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
         ws_relation_delete,
         ws_binding_set,
         ws_binding_delete,
+        ws_representation_set,
+        ws_representation_delete,
         ws_asset_get,
         ws_asset_list,
         ws_relation_list,

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from custom_components.bindhome.light import BindHomeLight
-from custom_components.bindhome.models import Asset, Binding
+from custom_components.bindhome.models import Asset, Binding, Representation
 from custom_components.bindhome.registry import BindHomeRegistry
 from custom_components.bindhome.resolver import (
     BindingResolver,
@@ -181,11 +181,40 @@ async def test_logical_light_leaves_unsupported_target_to_home_assistant(
     await logical.async_turn_on()
 
 
-async def test_assets_without_on_off_are_not_eligible() -> None:
+async def test_light_eligibility_requires_explicit_representation_and_on_off() -> None:
     registry = BindHomeRegistry()
-    asset = _asset(registry, ["dimming"])
 
-    assert BindHomeLight.is_eligible(asset) is False
+    eligible_asset = _asset(registry, ["on_off"])
+    eligible_representation = Representation.create(
+        asset_id=eligible_asset.id,
+        platform="light",
+    )
+
+    assert (
+        BindHomeLight.is_eligible(
+            eligible_asset,
+            eligible_representation,
+        )
+        is True
+    )
+
+    passive_asset = Asset.create(
+        name="Passive point",
+        asset_type="light_point",
+        capabilities=["dimming"],
+    )
+    passive_representation = Representation.create(
+        asset_id=passive_asset.id,
+        platform="light",
+    )
+
+    assert (
+        BindHomeLight.is_eligible(
+            passive_asset,
+            passive_representation,
+        )
+        is False
+    )
 
 
 async def test_logical_light_exposes_valid_on_off_light_attributes(

--- a/tests/test_light_reconciliation.py
+++ b/tests/test_light_reconciliation.py
@@ -1,4 +1,4 @@
-"""Runtime reconciliation tests for BindHome logical lights."""
+"""Runtime reconciliation tests for explicit BindHome light Representations."""
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -25,7 +25,34 @@ async def bindhome_entry(hass: HomeAssistant):
     await hass.async_block_till_done()
 
 
-async def test_asset_created_after_setup_adds_logical_light(
+async def test_on_off_asset_does_not_create_light_without_representation(
+    hass: HomeAssistant,
+    bindhome_entry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+
+    asset = await manager.async_create_asset(
+        name="Physical light point",
+        asset_type="light_point",
+        code="DYN-01",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+
+    assert (
+        registry.async_get_entity_id(
+            "light",
+            DOMAIN,
+            f"{DOMAIN}_{asset.id}",
+        )
+        is None
+    )
+
+
+async def test_setting_light_representation_adds_logical_light_dynamically(
     hass: HomeAssistant,
     bindhome_entry,
 ) -> None:
@@ -34,9 +61,14 @@ async def test_asset_created_after_setup_adds_logical_light(
     asset = await manager.async_create_asset(
         name="Dynamic light",
         asset_type="light_point",
-        code="DYN-01",
+        code="DYN-02",
         area_id=None,
         capabilities=["on_off"],
+    )
+
+    await manager.async_set_representation(
+        asset_id=asset.id,
+        platform="light",
     )
     await hass.async_block_till_done()
 
@@ -51,7 +83,7 @@ async def test_asset_created_after_setup_adds_logical_light(
     assert hass.states.get(entity_id) is not None
 
 
-async def test_existing_asset_becomes_logical_light_when_on_off_added(
+async def test_adding_on_off_capability_alone_does_not_infer_light(
     hass: HomeAssistant,
     bindhome_entry,
 ) -> None:
@@ -69,8 +101,6 @@ async def test_existing_asset_becomes_logical_light_when_on_off_added(
     registry = er.async_get(hass)
     unique_id = f"{DOMAIN}_{asset.id}"
 
-    assert registry.async_get_entity_id("light", DOMAIN, unique_id) is None
-
     await manager.async_update_asset(
         asset_id=asset.id,
         name=asset.name,
@@ -81,14 +111,15 @@ async def test_existing_asset_becomes_logical_light_when_on_off_added(
     )
     await hass.async_block_till_done()
 
-    entity_id = registry.async_get_entity_id(
-        "light",
-        DOMAIN,
-        unique_id,
-    )
+    assert registry.async_get_entity_id("light", DOMAIN, unique_id) is None
 
-    assert entity_id is not None
-    assert hass.states.get(entity_id) is not None
+    await manager.async_set_representation(
+        asset_id=asset.id,
+        platform="light",
+    )
+    await hass.async_block_till_done()
+
+    assert registry.async_get_entity_id("light", DOMAIN, unique_id) is not None
 
 
 async def test_logical_light_metadata_updates_without_identity_change(
@@ -103,6 +134,10 @@ async def test_logical_light_metadata_updates_without_identity_change(
         code="LGT-OLD",
         area_id=None,
         capabilities=["on_off"],
+    )
+    await manager.async_set_representation(
+        asset_id=asset.id,
+        platform="light",
     )
     await hass.async_block_till_done()
 
@@ -143,7 +178,7 @@ async def test_logical_light_metadata_updates_without_identity_change(
     assert registry_entry.original_name == "New name"
 
 
-async def test_removing_on_off_removes_logical_light_cleanly(
+async def test_removing_representation_removes_logical_light_but_keeps_asset(
     hass: HomeAssistant,
     bindhome_entry,
 ) -> None:
@@ -156,6 +191,10 @@ async def test_removing_on_off_removes_logical_light_cleanly(
         area_id=None,
         capabilities=["on_off"],
     )
+    await manager.async_set_representation(
+        asset_id=asset.id,
+        platform="light",
+    )
     await hass.async_block_till_done()
 
     registry = er.async_get(hass)
@@ -167,30 +206,18 @@ async def test_removing_on_off_removes_logical_light_cleanly(
     )
 
     assert entity_id is not None
-    assert hass.states.get(entity_id) is not None
 
-    await manager.async_update_asset(
-        asset_id=asset.id,
-        name=asset.name,
-        asset_type=asset.asset_type,
-        code=asset.code,
-        area_id=asset.area_id,
-        capabilities=[],
-    )
+    await manager.async_remove_representation(asset.id)
     await hass.async_block_till_done()
 
-    assert (
-        registry.async_get_entity_id(
-            "light",
-            DOMAIN,
-            unique_id,
-        )
-        is None
-    )
+    assert registry.async_get_entity_id("light", DOMAIN, unique_id) is None
     assert hass.states.get(entity_id) is None
 
+    # Physical identity remains in BindHome.
+    assert manager.registry.get_asset(asset.id).id == asset.id
 
-async def test_removed_capability_can_be_readded_with_same_entity_id(
+
+async def test_removed_representation_can_be_readded_with_same_entity_id(
     hass: HomeAssistant,
     bindhome_entry,
 ) -> None:
@@ -202,6 +229,10 @@ async def test_removed_capability_can_be_readded_with_same_entity_id(
         code=None,
         area_id=None,
         capabilities=["on_off"],
+    )
+    await manager.async_set_representation(
+        asset_id=asset.id,
+        platform="light",
     )
     await hass.async_block_till_done()
 
@@ -215,23 +246,12 @@ async def test_removed_capability_can_be_readded_with_same_entity_id(
     )
     assert original_entity_id is not None
 
-    await manager.async_update_asset(
-        asset_id=asset.id,
-        name=asset.name,
-        asset_type=asset.asset_type,
-        code=asset.code,
-        area_id=asset.area_id,
-        capabilities=[],
-    )
+    await manager.async_remove_representation(asset.id)
     await hass.async_block_till_done()
 
-    await manager.async_update_asset(
+    await manager.async_set_representation(
         asset_id=asset.id,
-        name=asset.name,
-        asset_type=asset.asset_type,
-        code=asset.code,
-        area_id=asset.area_id,
-        capabilities=["on_off"],
+        platform="light",
     )
     await hass.async_block_till_done()
 
@@ -243,44 +263,3 @@ async def test_removed_capability_can_be_readded_with_same_entity_id(
 
     assert restored_entity_id == original_entity_id
     assert hass.states.get(restored_entity_id) is not None
-
-
-async def test_deleting_asset_removes_logical_light_without_reload(
-    hass: HomeAssistant,
-    bindhome_entry,
-) -> None:
-    manager = bindhome_entry.runtime_data
-
-    asset = await manager.async_create_asset(
-        name="Disposable light",
-        asset_type="light_point",
-        code=None,
-        area_id=None,
-        capabilities=["on_off"],
-    )
-    await hass.async_block_till_done()
-
-    registry = er.async_get(hass)
-    unique_id = f"{DOMAIN}_{asset.id}"
-
-    entity_id = registry.async_get_entity_id(
-        "light",
-        DOMAIN,
-        unique_id,
-    )
-
-    assert entity_id is not None
-    assert hass.states.get(entity_id) is not None
-
-    await manager.async_delete_asset(asset.id)
-    await hass.async_block_till_done()
-
-    assert (
-        registry.async_get_entity_id(
-            "light",
-            DOMAIN,
-            unique_id,
-        )
-        is None
-    )
-    assert hass.states.get(entity_id) is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from custom_components.bindhome.models import (
     Binding,
     ModelValidationError,
     Relation,
+    Representation,
 )
 
 
@@ -144,6 +145,28 @@ def test_asset_serialization_deserialization() -> None:
                 "asset_type": "radiator",
                 "capabilities": "on_off",
             }
+        )
+
+
+def test_representation_creation_and_roundtrip() -> None:
+    representation = Representation.create(
+        asset_id="  asset-1  ",
+        platform="  LIGHT  ",
+    )
+
+    assert representation.asset_id == "asset-1"
+    assert representation.platform == "light"
+    assert Representation.from_dict(representation.to_dict()) == representation
+
+
+def test_representation_rejects_invalid_platform_identifier() -> None:
+    with pytest.raises(
+        ModelValidationError,
+        match="platform must use lower_snake_case",
+    ):
+        Representation.create(
+            asset_id="asset-1",
+            platform="Light Proxy",
         )
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -387,11 +387,13 @@ def test_registry_full_serialization_and_deserialization() -> None:
     assert len(data["assets"]) == 2
     assert len(data["relations"]) == 1
     assert len(data["bindings"]) == 1
+    assert len(data["representations"]) == 0
 
     restored = BindHomeRegistry.from_dict(data)
     assert len(restored.assets) == 2
     assert len(restored.relations) == 1
     assert len(restored.bindings) == 1
+    assert len(restored.representations) == 0
     assert restored.assets[source.id] == source
     assert restored.assets[target.id] == target
     assert restored.relations[relation.id] == relation

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -1,0 +1,255 @@
+"""Tests for explicit BindHome logical Representations."""
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from custom_components.bindhome.const import SIGNAL_REGISTRY_CHANGED
+from custom_components.bindhome.manager import BindHomeManager
+from custom_components.bindhome.models import Asset, Representation
+from custom_components.bindhome.registry import (
+    BindHomeRegistry,
+    RegistryConflictError,
+    RegistryNotFoundError,
+    RegistryValidationError,
+)
+
+
+def _light_asset(registry: BindHomeRegistry) -> Asset:
+    return registry.add_asset(
+        Asset.create(
+            name="Ceiling light",
+            asset_type="light_point",
+            capabilities=["on_off"],
+        )
+    )
+
+
+def test_representation_requires_existing_asset() -> None:
+    registry = BindHomeRegistry()
+
+    with pytest.raises(RegistryNotFoundError, match="was not found"):
+        registry.set_representation(
+            Representation.create(
+                asset_id="missing",
+                platform="light",
+            )
+        )
+
+
+def test_representation_platform_must_be_implemented_by_bindhome() -> None:
+    registry = BindHomeRegistry()
+    asset = _light_asset(registry)
+
+    with pytest.raises(
+        RegistryValidationError,
+        match="does not implement representation platform fan",
+    ):
+        registry.set_representation(
+            Representation.create(
+                asset_id=asset.id,
+                platform="fan",
+            )
+        )
+
+
+def test_light_representation_requires_on_off_capability() -> None:
+    registry = BindHomeRegistry()
+    asset = registry.add_asset(
+        Asset.create(
+            name="Passive light point",
+            asset_type="light_point",
+            capabilities=[],
+        )
+    )
+
+    with pytest.raises(
+        RegistryValidationError,
+        match="light representation requires capabilities: on_off",
+    ):
+        registry.set_representation(
+            Representation.create(
+                asset_id=asset.id,
+                platform="light",
+            )
+        )
+
+
+def test_representation_is_zero_or_one_and_same_platform_is_idempotent() -> None:
+    registry = BindHomeRegistry()
+    asset = _light_asset(registry)
+
+    first = registry.set_representation(
+        Representation.create(
+            asset_id=asset.id,
+            platform="light",
+        )
+    )
+    second = registry.set_representation(
+        Representation.create(
+            asset_id=asset.id,
+            platform="light",
+        )
+    )
+
+    assert first == second
+    assert registry.get_representation(asset.id) == first
+    assert len(registry.representations) == 1
+
+
+def test_required_capability_cannot_be_removed_while_representation_exists() -> None:
+    registry = BindHomeRegistry()
+    asset = _light_asset(registry)
+
+    registry.set_representation(
+        Representation.create(
+            asset_id=asset.id,
+            platform="light",
+        )
+    )
+
+    with pytest.raises(
+        RegistryConflictError,
+        match="Cannot remove capabilities required by active light representation",
+    ):
+        registry.update_asset_capabilities(asset.id, [])
+
+
+def test_asset_cannot_be_deleted_while_representation_exists() -> None:
+    registry = BindHomeRegistry()
+    asset = _light_asset(registry)
+
+    registry.set_representation(
+        Representation.create(
+            asset_id=asset.id,
+            platform="light",
+        )
+    )
+
+    with pytest.raises(
+        RegistryConflictError,
+        match="Cannot delete an asset with active representation",
+    ):
+        registry.delete_asset(asset.id)
+
+    registry.remove_representation(asset.id)
+    registry.delete_asset(asset.id)
+
+    assert asset.id not in registry.assets
+
+
+def test_representation_serialization_roundtrip() -> None:
+    registry = BindHomeRegistry()
+    asset = _light_asset(registry)
+
+    representation = registry.set_representation(
+        Representation.create(
+            asset_id=asset.id,
+            platform="light",
+        )
+    )
+
+    data = registry.to_dict()
+
+    assert data["representations"] == [representation.to_dict()]
+
+    restored = BindHomeRegistry.from_dict(data)
+
+    assert restored.get_representation(asset.id) == representation
+
+
+def test_legacy_registry_migrates_implicit_on_off_lights() -> None:
+    legacy = BindHomeRegistry.from_dict(
+        {
+            "schema_version": 1,
+            "assets": [
+                {
+                    "id": "old-light",
+                    "name": "Old light",
+                    "asset_type": "light_point",
+                    "capabilities": ["on_off"],
+                },
+                {
+                    "id": "old-socket",
+                    "name": "Passive socket",
+                    "asset_type": "socket",
+                    "capabilities": [],
+                },
+            ],
+            "relations": [],
+            "bindings": [],
+        }
+    )
+
+    representation = legacy.get_representation("old-light")
+
+    assert representation is not None
+    assert representation.platform == "light"
+    assert legacy.get_representation("old-socket") is None
+
+    # Once serialized by the new model, the distinction becomes explicit.
+    assert "representations" in legacy.to_dict()
+
+
+def test_explicit_empty_representation_list_disables_legacy_inference() -> None:
+    registry = BindHomeRegistry.from_dict(
+        {
+            "schema_version": 1,
+            "assets": [
+                {
+                    "id": "new-light-point",
+                    "name": "New light point",
+                    "asset_type": "light_point",
+                    "capabilities": ["on_off"],
+                }
+            ],
+            "relations": [],
+            "bindings": [],
+            "representations": [],
+        }
+    )
+
+    assert registry.get_representation("new-light-point") is None
+
+
+async def test_manager_representation_lifecycle_persists_and_notifies(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+
+    asset = await manager.async_create_asset(
+        name="Logical candidate",
+        asset_type="light_point",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
+
+    notifications: list[None] = []
+    unsubscribe = async_dispatcher_connect(
+        hass,
+        SIGNAL_REGISTRY_CHANGED,
+        lambda: notifications.append(None),
+    )
+
+    representation = await manager.async_set_representation(
+        asset_id=asset.id,
+        platform="light",
+    )
+    await hass.async_block_till_done()
+
+    assert representation.platform == "light"
+    assert manager.registry.get_representation(asset.id) == representation
+
+    await manager.async_remove_representation(asset.id)
+    await hass.async_block_till_done()
+
+    assert manager.registry.get_representation(asset.id) is None
+    assert notifications == [None, None]
+
+    reloaded = BindHomeManager(hass)
+    await reloaded.async_load()
+    assert reloaded.registry.get_representation(asset.id) is None
+
+    unsubscribe()

--- a/tests/test_store_manager.py
+++ b/tests/test_store_manager.py
@@ -16,6 +16,7 @@ async def test_store_empty_initial(hass: HomeAssistant) -> None:
     assert len(registry.assets) == 0
     assert len(registry.relations) == 0
     assert len(registry.bindings) == 0
+    assert len(registry.representations) == 0
 
 
 async def test_manager_load_and_persist(hass: HomeAssistant) -> None:

--- a/tests/test_system_health.py
+++ b/tests/test_system_health.py
@@ -40,6 +40,7 @@ async def test_system_health_loaded(hass: HomeAssistant) -> None:
         "assets": 1,
         "relations": 0,
         "bindings": 0,
+        "representations": 0,
     }
 
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -10,7 +10,12 @@ import pytest
 import voluptuous as vol
 
 from custom_components.bindhome import websocket
-from custom_components.bindhome.models import Asset, Binding, Relation
+from custom_components.bindhome.models import (
+    Asset,
+    Binding,
+    Relation,
+    Representation,
+)
 from custom_components.bindhome.registry import (
     BindHomeRegistry,
     RegistryConflictError,
@@ -45,6 +50,7 @@ class FakeManager:
             "assets": [],
             "relations": [],
             "bindings": [],
+            "representations": [],
         }
         self.async_create_asset = AsyncMock()
         self.async_create_assets = AsyncMock()
@@ -54,6 +60,8 @@ class FakeManager:
         self.async_remove_relation = AsyncMock()
         self.async_set_binding = AsyncMock()
         self.async_remove_binding = AsyncMock()
+        self.async_set_representation = AsyncMock()
+        self.async_remove_representation = AsyncMock()
 
 
 def hass_for(manager: FakeManager) -> SimpleNamespace:
@@ -538,6 +546,86 @@ async def test_binding_set_replaces_and_delete_serialize_binding() -> None:
 
 
 @pytest.mark.asyncio
+async def test_representation_set_and_delete_websocket_contracts() -> None:
+    manager = FakeManager()
+    representation = Representation.create(
+        asset_id="asset-1",
+        platform="light",
+    )
+    manager.async_set_representation.return_value = representation
+
+    connection = FakeConnection()
+    hass = hass_for(manager)
+
+    await call(
+        websocket.ws_representation_set,
+        hass,
+        connection,
+        {
+            "id": "1",
+            "asset_id": "asset-1",
+            "platform": "light",
+        },
+    )
+
+    await call(
+        websocket.ws_representation_delete,
+        hass,
+        connection,
+        {
+            "id": "2",
+            "asset_id": "asset-1",
+        },
+    )
+
+    manager.async_set_representation.assert_awaited_once_with(
+        asset_id="asset-1",
+        platform="light",
+    )
+    manager.async_remove_representation.assert_awaited_once_with("asset-1")
+
+    assert connection.results == [
+        (
+            "1",
+            {"representation": representation.to_dict()},
+        ),
+        (
+            "2",
+            {"deleted": True},
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_representation_validation_error_is_structured() -> None:
+    manager = FakeManager()
+    manager.async_set_representation.side_effect = RegistryValidationError(
+        "light representation requires capabilities: on_off",
+        field="capabilities",
+    )
+    connection = FakeConnection()
+
+    await call(
+        websocket.ws_representation_set,
+        hass_for(manager),
+        connection,
+        {
+            "id": "1",
+            "asset_id": "asset-1",
+            "platform": "light",
+        },
+    )
+
+    assert connection.errors == [
+        (
+            "1",
+            "invalid_format",
+            "light representation requires capabilities: on_off",
+        )
+    ]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("handler", "error"),
     [
@@ -625,6 +713,8 @@ def test_registers_all_commands_under_bindhome_namespace() -> None:
         websocket.WS_RELATION_DELETE,
         websocket.WS_BINDING_SET,
         websocket.WS_BINDING_DELETE,
+        websocket.WS_REPRESENTATION_SET,
+        websocket.WS_REPRESENTATION_DELETE,
         websocket.WS_ASSET_GET,
         websocket.WS_ASSET_LIST,
         websocket.WS_RELATION_LIST,


### PR DESCRIPTION
## Summary

- add explicit optional `Representation` objects so Asset capability no longer implicitly determines Home Assistant entity type
- model Representation as `asset_id + platform`, with initial cardinality `0..1` per Asset
- make `light` require both an explicit `light` Representation and the BindHome `on_off` capability
- add Representation lifecycle to the manager and WebSocket API
- persist Representations in the BindHome registry and include them in system health
- preserve existing staged bulk mutation behavior by carrying Representations through P0-A commits
- prevent removing capabilities required by an active Representation
- prevent deleting an Asset while a Representation exists
- derive forwarded BindHome platforms from the single BindHome-owned `REPRESENTATION_REQUIREMENTS` contract instead of duplicating platform knowledge

## Compatibility / migration

Persisted registries from before P0-B do not contain a `representations` key. On first load, BindHome migrates the previous implicit behavior by creating an explicit `light` Representation for Assets that already had `on_off`.

Once serialized by the new model, `representations` is always present. An explicit empty list means no logical representation and therefore no future implicit inference.

This preserves the existing RA-06 logical light behavior while moving the product to the explicit model.

## Runtime behavior

- `on_off` alone no longer creates a logical `light.*`
- adding a `light` Representation dynamically creates the logical light
- removing the Representation removes the logical entity but preserves the physical Asset
- re-adding the Representation preserves the stable logical entity identity
- metadata updates still preserve entity identity
- Home Assistant remains authoritative for actual service routing and backend entity behavior

## API

Adds WebSocket commands:

- `bindhome/representations/set`
- `bindhome/representations/delete`

No duplicate Home Assistant service surface is added for this UI-oriented configuration primitive.

## Validation

Local validation on commit `bc38dda`:

- `ruff check .` — PASS
- `ruff format --check .` — PASS
- `git diff --check` — PASS
- targeted P0-B tests — `110 passed`
- full suite — `167 passed`

Coverage includes model normalization, registry validation, serialization round-trip, legacy migration, explicit-empty behavior, manager persistence/notifications, dynamic light reconciliation, stable re-creation, WebSocket contracts, system health, and P0-A staged-registry preservation.

## Next

After merge, P0-C will introduce the extensible creation preset catalogue for high-volume room inventory without turning presets into backend validation rules or automatic logical representations.