### PR TITLE
Add extensible creation presets

### DIFF
--- a/custom_components/bindhome/presets.py
+++ b/custom_components/bindhome/presets.py
@@ -1,0 +1,131 @@
+"""Built-in creation presets for high-volume BindHome inventory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from .models import normalize_identifier, normalize_non_empty
+
+
+@dataclass(frozen=True, slots=True)
+class CreationPreset:
+    """UX metadata that suggests an editable Asset draft."""
+
+    preset_id: str
+    group: str
+    asset_type: str
+    default_name: str
+    suggested_capabilities: tuple[str, ...] = ()
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        preset_id: str,
+        group: str,
+        asset_type: str,
+        default_name: str,
+        suggested_capabilities: tuple[str, ...] = (),
+    ) -> CreationPreset:
+        """Create normalized preset metadata."""
+        return cls(
+            preset_id=normalize_identifier(preset_id, "preset_id"),
+            group=normalize_identifier(group, "group"),
+            asset_type=normalize_identifier(asset_type, "asset_type"),
+            default_name=normalize_non_empty(default_name, "default_name"),
+            suggested_capabilities=tuple(
+                sorted(
+                    {
+                        normalize_identifier(capability, "capability")
+                        for capability in suggested_capabilities
+                    }
+                )
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize preset metadata for user-facing clients."""
+        return {
+            "preset_id": self.preset_id,
+            "group": self.group,
+            "asset_type": self.asset_type,
+            "default_name": self.default_name,
+            "suggested_capabilities": list(self.suggested_capabilities),
+        }
+
+
+def _preset(
+    asset_type: str,
+    group: str,
+    default_name: str,
+    *capabilities: str,
+) -> CreationPreset:
+    """Build one built-in preset using its Asset type as stable preset ID."""
+    return CreationPreset.create(
+        preset_id=asset_type,
+        group=group,
+        asset_type=asset_type,
+        default_name=default_name,
+        suggested_capabilities=capabilities,
+    )
+
+
+# Order is intentional: it defines the default inventory questionnaire order.
+#
+# Presets are suggestions only. They do not restrict custom asset_type values,
+# custom capabilities, bindings or logical Representations.
+CREATION_PRESETS: Final[tuple[CreationPreset, ...]] = (
+    # Electrical
+    _preset("light_point", "electrical", "Light point", "on_off"),
+    _preset("socket", "electrical", "Socket"),
+    _preset("switch", "electrical", "Switch", "on_off"),
+    _preset("electrical_panel", "electrical", "Electrical panel"),
+    _preset("circuit", "electrical", "Circuit"),
+    _preset("junction_box", "electrical", "Junction box"),
+    # Network and communications
+    _preset("ethernet_outlet", "network", "Ethernet outlet"),
+    _preset("telephone_outlet", "network", "Telephone outlet"),
+    _preset("antenna_outlet", "network", "Antenna outlet"),
+    _preset("wifi_access_point", "network", "Wi-Fi access point"),
+    # Climate
+    _preset("radiator", "climate", "Radiator"),
+    _preset(
+        "thermostat",
+        "climate",
+        "Thermostat",
+        "temperature",
+        "setpoint",
+    ),
+    _preset("fan", "climate", "Fan", "on_off"),
+    _preset(
+        "air_conditioning_unit",
+        "climate",
+        "Air-conditioning unit",
+        "on_off",
+        "setpoint",
+    ),
+    # Water
+    _preset("tap", "water", "Tap", "open_close"),
+    _preset("shutoff_valve", "water", "Shut-off valve", "open_close"),
+    _preset("valve", "water", "Valve", "open_close"),
+    _preset("drain", "water", "Drain"),
+    _preset("manifold", "water", "Manifold"),
+    # Building
+    _preset("door", "building", "Door", "open_close"),
+    _preset("window", "building", "Window", "open_close"),
+    _preset("blind", "building", "Blind", "open_close", "position"),
+    _preset("skylight", "building", "Skylight", "open_close"),
+    # Equipment
+    _preset("boiler", "equipment", "Boiler", "on_off"),
+    _preset("water_heater", "equipment", "Water heater", "on_off"),
+    _preset("pump", "equipment", "Pump", "on_off"),
+    _preset("freezer", "equipment", "Freezer", "on_off"),
+    _preset("appliance", "equipment", "Appliance", "on_off"),
+    _preset("machine", "equipment", "Machine", "on_off"),
+)
+
+
+def list_creation_presets() -> tuple[CreationPreset, ...]:
+    """Return the built-in catalogue in deterministic questionnaire order."""
+    return CREATION_PRESETS

--- a/custom_components/bindhome/websocket.py
+++ b/custom_components/bindhome/websocket.py
@@ -30,6 +30,7 @@ from .manager import (
     BulkAssetCreateError,
 )
 from .models import ModelValidationError
+from .presets import list_creation_presets
 from .query import Direction
 from .registry import (
     RegistryConflictError,
@@ -50,6 +51,7 @@ WS_BINDING_SET = f"{DOMAIN}/bindings/set"
 WS_BINDING_DELETE = f"{DOMAIN}/bindings/delete"
 WS_REPRESENTATION_SET = f"{DOMAIN}/representations/set"
 WS_REPRESENTATION_DELETE = f"{DOMAIN}/representations/delete"
+WS_PRESET_LIST = f"{DOMAIN}/presets/list"
 WS_ASSET_GET = f"{DOMAIN}/assets/get"
 WS_ASSET_LIST = f"{DOMAIN}/assets/list"
 WS_RELATION_LIST = f"{DOMAIN}/relations/list"
@@ -422,6 +424,23 @@ async def ws_representation_delete(
 
 
 @require_admin
+@websocket_command({vol.Required("type"): WS_PRESET_LIST})
+@async_response
+async def ws_preset_list(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return built-in creation presets in deterministic UX order."""
+    del hass
+
+    connection.send_result(
+        msg["id"],
+        {"presets": [preset.to_dict() for preset in list_creation_presets()]},
+    )
+
+
+@require_admin
 @websocket_command(
     {vol.Required("type"): WS_ASSET_GET, vol.Required("asset_id"): cv.string}
 )
@@ -588,6 +607,7 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
         ws_binding_delete,
         ws_representation_set,
         ws_representation_delete,
+        ws_preset_list,
         ws_asset_get,
         ws_asset_list,
         ws_relation_list,

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,124 @@
+"""Tests for BindHome built-in creation presets."""
+
+from custom_components.bindhome.models import Asset
+from custom_components.bindhome.presets import (
+    CREATION_PRESETS,
+    CreationPreset,
+    list_creation_presets,
+)
+
+EXPECTED_GROUP_ORDER = (
+    "electrical",
+    "network",
+    "climate",
+    "water",
+    "building",
+    "equipment",
+)
+
+
+def test_builtin_preset_catalogue_is_stable_and_unique() -> None:
+    presets = list_creation_presets()
+
+    assert presets is CREATION_PRESETS
+    assert len(presets) == 29
+
+    preset_ids = [preset.preset_id for preset in presets]
+    asset_types = [preset.asset_type for preset in presets]
+
+    assert len(preset_ids) == len(set(preset_ids))
+    assert len(asset_types) == len(set(asset_types))
+
+    # Built-ins intentionally use asset_type as their stable preset identity.
+    assert preset_ids == asset_types
+
+
+def test_builtin_groups_follow_inventory_questionnaire_order() -> None:
+    groups = tuple(dict.fromkeys(preset.group for preset in CREATION_PRESETS))
+
+    assert groups == EXPECTED_GROUP_ORDER
+
+
+def test_every_preset_produces_a_valid_editable_asset_draft() -> None:
+    for preset in CREATION_PRESETS:
+        asset = Asset.create(
+            name=preset.default_name,
+            asset_type=preset.asset_type,
+            capabilities=list(preset.suggested_capabilities),
+        )
+
+        assert asset.name == preset.default_name
+        assert asset.asset_type == preset.asset_type
+        assert asset.capabilities == preset.suggested_capabilities
+
+
+def test_preset_serialization_contains_only_ux_suggestions() -> None:
+    preset = CreationPreset.create(
+        preset_id="test_device",
+        group="equipment",
+        asset_type="test_device",
+        default_name="Test device",
+        suggested_capabilities=("on_off",),
+    )
+
+    assert preset.to_dict() == {
+        "preset_id": "test_device",
+        "group": "equipment",
+        "asset_type": "test_device",
+        "default_name": "Test device",
+        "suggested_capabilities": ["on_off"],
+    }
+
+    # Inventory presets must never imply automation or HA exposure.
+    assert "representation" not in preset.to_dict()
+    assert "binding" not in preset.to_dict()
+    assert "entity_id" not in preset.to_dict()
+
+
+def test_preset_capabilities_are_normalized_suggestions() -> None:
+    preset = CreationPreset.create(
+        preset_id="example",
+        group="equipment",
+        asset_type="example_device",
+        default_name="Example",
+        suggested_capabilities=(
+            "position",
+            "on_off",
+            "position",
+        ),
+    )
+
+    assert preset.suggested_capabilities == ("on_off", "position")
+
+
+def test_custom_assets_remain_valid_without_any_preset() -> None:
+    asset = Asset.create(
+        name="Solar inverter",
+        asset_type="solar_inverter",
+        capabilities=["generation", "power_measurement"],
+    )
+
+    assert asset.asset_type == "solar_inverter"
+    assert asset.capabilities == ("generation", "power_measurement")
+    assert all(preset.asset_type != asset.asset_type for preset in CREATION_PRESETS)
+
+
+def test_socket_preset_does_not_assume_switchability() -> None:
+    socket = next(preset for preset in CREATION_PRESETS if preset.preset_id == "socket")
+
+    assert socket.suggested_capabilities == ()
+
+
+def test_light_point_suggests_capability_but_not_representation() -> None:
+    light_point = next(
+        preset for preset in CREATION_PRESETS if preset.preset_id == "light_point"
+    )
+
+    assert light_point.suggested_capabilities == ("on_off",)
+    assert set(light_point.to_dict()) == {
+        "preset_id",
+        "group",
+        "asset_type",
+        "default_name",
+        "suggested_capabilities",
+    }

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -715,6 +715,7 @@ def test_registers_all_commands_under_bindhome_namespace() -> None:
         websocket.WS_BINDING_DELETE,
         websocket.WS_REPRESENTATION_SET,
         websocket.WS_REPRESENTATION_DELETE,
+        websocket.WS_PRESET_LIST,
         websocket.WS_ASSET_GET,
         websocket.WS_ASSET_LIST,
         websocket.WS_RELATION_LIST,
@@ -756,6 +757,41 @@ def _sample_registry() -> BindHomeRegistry:
         )
     )
     return registry
+
+
+@pytest.mark.asyncio
+async def test_preset_list_returns_read_only_catalogue_without_manager() -> None:
+    connection = FakeConnection()
+
+    await call(
+        websocket.ws_preset_list,
+        SimpleNamespace(),
+        connection,
+        {"id": "presets"},
+    )
+
+    assert len(connection.results) == 1
+
+    message_id, result = connection.results[0]
+
+    assert message_id == "presets"
+    assert len(result["presets"]) == 29
+
+    first = result["presets"][0]
+    assert first == {
+        "preset_id": "light_point",
+        "group": "electrical",
+        "asset_type": "light_point",
+        "default_name": "Light point",
+        "suggested_capabilities": ["on_off"],
+    }
+
+    assert all(
+        "representation" not in preset
+        and "binding" not in preset
+        and "entity_id" not in preset
+        for preset in result["presets"]
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a built-in catalogue of 29 creation presets for high-volume home inventory
- group presets into electrical, network, climate, water, building and equipment sections
- expose presets through the read-only `bindhome/presets/list` WebSocket command
- keep presets as editable UX suggestions only: `preset_id`, `group`, `asset_type`, `default_name`, and `suggested_capabilities`
- preserve unrestricted custom Asset types and custom capabilities
- keep Asset creation on the existing normal/bulk paths; no `create_from_preset` API is added
- do not create Bindings, entity references, or Representations from presets

## Architecture

This implements P0-C from the inventory-first product contract.

Presets are not backend enums and are not validation rules. They exist only to help the future room-inventory UX generate editable Asset drafts quickly. The actual save path remains the transactional bulk Asset creation primitive introduced in P0-A.

A preset may suggest capabilities but never implies Home Assistant compatibility, automation, hardware binding, or logical exposure. P0-B Representation remains explicit and independent.

Home Assistant continues to own Floors, Areas, Devices, Entities, domains, states, supported features and services. The preset catalogue contains only BindHome-owned UX metadata for physical inventory.

## Built-in catalogue

29 initial presets across six groups:

- Electrical: light point, socket, switch, electrical panel, circuit, junction box
- Network: Ethernet outlet, telephone outlet, antenna outlet, Wi-Fi access point
- Climate: radiator, thermostat, fan, air-conditioning unit
- Water: tap, shut-off valve, valve, drain, manifold
- Building: door, window, blind, skylight
- Equipment: boiler, water heater, pump, freezer, appliance, machine

The ordering is deterministic and intentionally matches the future room-inventory questionnaire.

## API

Adds one read-only WebSocket command:

- `bindhome/presets/list`

No Home Assistant service is added and no preset-specific write path exists.

## Validation

Local validation on commit `9ccbae2`:

- `ruff format --check .` — PASS
- `ruff check .` — PASS
- `git diff --check` — PASS
- targeted P0-C tests — `72 passed`
- full suite — `176 passed`
- semantic architecture checks — PASS

Coverage verifies:

- all 29 built-in presets have unique stable IDs
- group/questionnaire ordering is deterministic
- every preset produces a valid ordinary Asset draft
- preset payloads contain no Representation, Binding or entity reference fields
- suggested capabilities are normalized but remain suggestions
- sockets do not assume switchability
- light points may suggest `on_off` without creating a logical light
- custom Asset types and capabilities remain unrestricted
- no second preset-driven Asset creation path exists
- WebSocket catalogue output is deterministic and read-only

## Next

After merge, P0-D will synchronize the architecture/product documentation with the now-implemented P0-A, P0-B and P0-C foundations. Once that is merged, the functional base is closed and the first user-facing milestone can begin: Area-oriented **Inventory this room**.