### PR TITLE
refactor: make all manager mutations transactional

### DIFF
--- a/custom_components/bindhome/manager.py
+++ b/custom_components/bindhome/manager.py
@@ -103,17 +103,25 @@ class BindHomeManager:
         """Return a resolver bound to the current registry and Home Assistant."""
         return BindingResolver(self.registry, self._probe)
 
-    async def _async_persist_and_notify(self) -> None:
-        """Persist the registry and notify runtime consumers."""
-        await self._store.async_save(self.registry)
+    def _stage_registry(self) -> BindHomeRegistry:
+        """Return an isolated validated copy of the live registry."""
+        return BindHomeRegistry.from_dict(self.registry.to_dict())
+
+    async def _async_commit_staged_registry(
+        self,
+        staged: BindHomeRegistry,
+    ) -> None:
+        """Persist staged state, then atomically publish it to runtime consumers."""
+        await self._store.async_save(staged)
+        self._adopt_staged_registry(staged)
         async_dispatcher_send(self.hass, SIGNAL_REGISTRY_CHANGED)
 
     def _adopt_staged_registry(self, staged: BindHomeRegistry) -> None:
         """Commit staged state while preserving the live registry identity.
 
         Long-lived runtime consumers may retain references to the current
-        BindHomeRegistry, so batch commits replace its contents rather than
-        replacing the registry object itself.
+        BindHomeRegistry, so commits replace its contents rather than replacing
+        the registry object itself.
         """
         self.registry.assets.clear()
         self.registry.assets.update(staged.assets)
@@ -142,7 +150,8 @@ class BindHomeManager:
     ) -> Asset:
         """Create and persist an asset."""
         async with self._mutation_lock:
-            asset = self.registry.add_asset(
+            staged = self._stage_registry()
+            asset = staged.add_asset(
                 Asset.create(
                     name=name,
                     asset_type=asset_type,
@@ -151,7 +160,7 @@ class BindHomeManager:
                     capabilities=capabilities,
                 )
             )
-            await self._async_persist_and_notify()
+            await self._async_commit_staged_registry(staged)
             return asset
 
     async def async_create_assets(
@@ -163,7 +172,7 @@ class BindHomeManager:
             raise ValueError("assets must contain at least one item")
 
         async with self._mutation_lock:
-            staged = BindHomeRegistry.from_dict(self.registry.to_dict())
+            staged = self._stage_registry()
             created: list[Asset] = []
 
             for index, spec in enumerate(specs):
@@ -181,14 +190,7 @@ class BindHomeManager:
 
                 created.append(asset)
 
-            # Persistence is deliberately performed before changing the live
-            # registry. If storage fails, the running registry remains exactly
-            # as it was before the batch.
-            await self._store.async_save(staged)
-
-            self._adopt_staged_registry(staged)
-            async_dispatcher_send(self.hass, SIGNAL_REGISTRY_CHANGED)
-
+            await self._async_commit_staged_registry(staged)
             return created
 
     async def async_update_asset(
@@ -203,7 +205,8 @@ class BindHomeManager:
     ) -> Asset:
         """Update and persist an asset without changing its identity."""
         async with self._mutation_lock:
-            asset = self.registry.update_asset(
+            staged = self._stage_registry()
+            asset = staged.update_asset(
                 asset_id,
                 name=name,
                 asset_type=asset_type,
@@ -211,35 +214,38 @@ class BindHomeManager:
                 area_id=area_id,
                 capabilities=capabilities,
             )
-            await self._async_persist_and_notify()
+            await self._async_commit_staged_registry(staged)
             return asset
 
     async def async_delete_asset(self, asset_id: str) -> None:
         """Delete and persist an asset."""
         async with self._mutation_lock:
-            self.registry.delete_asset(asset_id)
-            await self._async_persist_and_notify()
+            staged = self._stage_registry()
+            staged.delete_asset(asset_id)
+            await self._async_commit_staged_registry(staged)
 
     async def async_add_relation(
         self, *, source_asset_id: str, relation_type: str, target_asset_id: str
     ) -> Relation:
         """Create and persist a topology relation."""
         async with self._mutation_lock:
-            relation = self.registry.add_relation(
+            staged = self._stage_registry()
+            relation = staged.add_relation(
                 Relation.create(
                     source_asset_id=source_asset_id,
                     relation_type=relation_type,
                     target_asset_id=target_asset_id,
                 )
             )
-            await self._async_persist_and_notify()
+            await self._async_commit_staged_registry(staged)
             return relation
 
     async def async_remove_relation(self, relation_id: str) -> None:
         """Remove and persist a topology relation."""
         async with self._mutation_lock:
-            self.registry.remove_relation(relation_id)
-            await self._async_persist_and_notify()
+            staged = self._stage_registry()
+            staged.remove_relation(relation_id)
+            await self._async_commit_staged_registry(staged)
 
     async def async_set_binding(
         self,
@@ -251,20 +257,26 @@ class BindHomeManager:
     ) -> Binding:
         """Create or replace and persist a capability binding."""
         async with self._mutation_lock:
+            staged = self._stage_registry()
             binding = Binding.create(
                 asset_id=asset_id,
                 capability=capability,
                 entity_id=entity_id,
                 role=role,
             )
-            self._validate_binding_target(binding)
-            binding = self.registry.set_binding(binding)
-            await self._async_persist_and_notify()
+            self._validate_binding_target(binding, registry=staged)
+            binding = staged.set_binding(binding)
+            await self._async_commit_staged_registry(staged)
             return binding
 
-    def _validate_binding_target(self, proposed: Binding) -> None:
+    def _validate_binding_target(
+        self,
+        proposed: Binding,
+        *,
+        registry: BindHomeRegistry,
+    ) -> None:
         """Validate HA target and reject only functional BindHome cycles."""
-        asset = self.registry.get_asset(proposed.asset_id)
+        asset = registry.get_asset(proposed.asset_id)
         if proposed.capability not in asset.capabilities:
             raise RegistryValidationError(
                 f"Asset {proposed.asset_id} does not declare capability "
@@ -275,28 +287,28 @@ class BindHomeManager:
 
         source = binding_key(proposed)
         adjacency: dict[tuple[str, str, str], set[tuple[str, str, str]]] = {}
-        for existing in self.registry.bindings.values():
+        for existing in registry.bindings.values():
             key = binding_key(existing)
             if key == source:
                 continue
             target_asset = representation_asset_for_entity(
-                self.hass, existing.entity_id, self.registry.representations
+                self.hass, existing.entity_id, registry.representations
             )
             if target_asset is None:
                 continue
             contract = runtime_contract(
-                self.registry.representations[target_asset], target_asset
+                registry.representations[target_asset], target_asset
             )
             if contract is not None:
                 adjacency.setdefault(key, set()).update(contract.dependencies)
 
         target_asset = representation_asset_for_entity(
-            self.hass, proposed.entity_id, self.registry.representations
+            self.hass, proposed.entity_id, registry.representations
         )
         if target_asset is None:
             return
         contract = runtime_contract(
-            self.registry.representations[target_asset], target_asset
+            registry.representations[target_asset], target_asset
         )
         if contract is None:
             return
@@ -331,8 +343,9 @@ class BindHomeManager:
     async def async_remove_binding(self, binding_id: str) -> None:
         """Remove and persist a binding."""
         async with self._mutation_lock:
-            self.registry.remove_binding(binding_id)
-            await self._async_persist_and_notify()
+            staged = self._stage_registry()
+            staged.remove_binding(binding_id)
+            await self._async_commit_staged_registry(staged)
 
     async def async_set_representation(
         self,
@@ -342,17 +355,19 @@ class BindHomeManager:
     ) -> Representation:
         """Create and persist an Asset's logical representation."""
         async with self._mutation_lock:
-            representation = self.registry.set_representation(
+            staged = self._stage_registry()
+            representation = staged.set_representation(
                 Representation.create(
                     asset_id=asset_id,
                     platform=platform,
                 )
             )
-            await self._async_persist_and_notify()
+            await self._async_commit_staged_registry(staged)
             return representation
 
     async def async_remove_representation(self, asset_id: str) -> None:
         """Remove and persist an Asset's logical representation."""
         async with self._mutation_lock:
-            self.registry.remove_representation(asset_id)
-            await self._async_persist_and_notify()
+            staged = self._stage_registry()
+            staged.remove_representation(asset_id)
+            await self._async_commit_staged_registry(staged)

--- a/custom_components/bindhome/store.py
+++ b/custom_components/bindhome/store.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
+from homeassistant.util import json as json_util
+from homeassistant.util.file import WriteError
 
 from .const import STORAGE_KEY, STORAGE_VERSION
 from .registry import BindHomeRegistry
@@ -21,7 +23,7 @@ class _FailFastStore(Store[dict[str, Any]]):
     async def _async_write_data(self, data: dict[str, Any]) -> None:
         try:
             await super()._async_write_data(data)
-        except Exception as err:
+        except (json_util.SerializationError, WriteError) as err:
             raise BindHomeStoreError("Failed to persist BindHome registry") from err
 
 

--- a/custom_components/bindhome/store.py
+++ b/custom_components/bindhome/store.py
@@ -11,14 +11,29 @@ from .const import STORAGE_KEY, STORAGE_VERSION
 from .registry import BindHomeRegistry
 
 
+class BindHomeStoreError(RuntimeError):
+    """Raised when Home Assistant cannot persist the BindHome registry."""
+
+
+class _FailFastStore(Store[dict[str, Any]]):
+    """Surface write failures that Home Assistant's Store normally logs only."""
+
+    async def _async_write_data(self, data: dict[str, Any]) -> None:
+        try:
+            await super()._async_write_data(data)
+        except Exception as err:
+            raise BindHomeStoreError("Failed to persist BindHome registry") from err
+
+
 class BindHomeStore:
     """Persist the BindHome registry using Home Assistant storage."""
 
     def __init__(self, hass: HomeAssistant) -> None:
-        self._store: Store[dict[str, Any]] = Store(
+        self._store: Store[dict[str, Any]] = _FailFastStore(
             hass,
             STORAGE_VERSION,
             STORAGE_KEY,
+            atomic_writes=True,
         )
 
     async def async_load(self) -> BindHomeRegistry:
@@ -26,5 +41,5 @@ class BindHomeStore:
         return BindHomeRegistry.from_dict(await self._store.async_load())
 
     async def async_save(self, registry: BindHomeRegistry) -> None:
-        """Persist the registry immediately."""
+        """Persist the registry immediately or raise on storage failure."""
         await self._store.async_save(registry.to_dict())

--- a/tests/test_binding_cycles.py
+++ b/tests/test_binding_cycles.py
@@ -32,7 +32,7 @@ def _logical_entity(hass: HomeAssistant, asset: Asset) -> str:
 @pytest.fixture
 def manager(hass: HomeAssistant) -> BindHomeManager:
     value = BindHomeManager(hass)
-    value._async_persist_and_notify = AsyncMock()  # type: ignore[method-assign]
+    value._store.async_save = AsyncMock()
     return value
 
 
@@ -73,9 +73,7 @@ async def test_bindhome_composition_is_acyclic_and_self_cycle_is_rejected(
         )
 
     assert len(manager.registry.bindings) == 2
-    assert (
-        manager._async_persist_and_notify.await_count == 2  # type: ignore[attr-defined]
-    )
+    assert manager._store.async_save.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -357,4 +355,4 @@ async def test_cycle_failure_is_atomic(
             role="primary",
         )
     assert not manager.registry.bindings
-    manager._async_persist_and_notify.assert_not_awaited()  # type: ignore[attr-defined]
+    manager._store.async_save.assert_not_awaited()

--- a/tests/test_manager_transactions.py
+++ b/tests/test_manager_transactions.py
@@ -1,0 +1,346 @@
+"""Failure-atomicity tests for BindHomeManager mutations."""
+
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from custom_components.bindhome.const import SIGNAL_REGISTRY_CHANGED
+from custom_components.bindhome.manager import BindHomeManager
+
+
+async def _assert_storage_failure_is_atomic(
+    hass: HomeAssistant,
+    manager: BindHomeManager,
+    mutation: Callable[[], Awaitable[object | None]],
+) -> None:
+    """Assert a failed save publishes neither staged RAM nor a change signal."""
+    original_registry = manager.registry
+    baseline = manager.registry.to_dict()
+
+    notifications: list[None] = []
+    unsubscribe = async_dispatcher_connect(
+        hass,
+        SIGNAL_REGISTRY_CHANGED,
+        lambda: notifications.append(None),
+    )
+
+    manager._store.async_save = AsyncMock(
+        side_effect=RuntimeError("storage failed"),
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="storage failed"):
+            await mutation()
+
+        await hass.async_block_till_done()
+
+        assert manager._store.async_save.await_count == 1
+        assert manager.registry is original_registry
+        assert manager.registry.to_dict() == baseline
+        assert notifications == []
+
+        reloaded = BindHomeManager(hass)
+        await reloaded.async_load()
+        assert reloaded.registry.to_dict() == baseline
+    finally:
+        unsubscribe()
+
+
+async def test_create_asset_storage_failure_is_atomic(hass: HomeAssistant) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+
+    await _assert_storage_failure_is_atomic(
+        hass,
+        manager,
+        lambda: manager.async_create_asset(
+            name="New socket",
+            asset_type="socket",
+            code="SOCK-01",
+            area_id=None,
+            capabilities=[],
+        ),
+    )
+
+
+async def test_update_asset_storage_failure_is_atomic(hass: HomeAssistant) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    asset = await manager.async_create_asset(
+        name="Original",
+        asset_type="socket",
+        code="SOCK-01",
+        area_id=None,
+        capabilities=[],
+    )
+
+    await _assert_storage_failure_is_atomic(
+        hass,
+        manager,
+        lambda: manager.async_update_asset(
+            asset_id=asset.id,
+            name="Renamed",
+            asset_type="socket",
+            code="SOCK-02",
+            area_id="living_room",
+            capabilities=[],
+        ),
+    )
+
+
+async def test_delete_asset_storage_failure_is_atomic(hass: HomeAssistant) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    asset = await manager.async_create_asset(
+        name="Socket",
+        asset_type="socket",
+        code="SOCK-01",
+        area_id=None,
+        capabilities=[],
+    )
+
+    await _assert_storage_failure_is_atomic(
+        hass,
+        manager,
+        lambda: manager.async_delete_asset(asset.id),
+    )
+
+
+async def test_add_relation_storage_failure_is_atomic(hass: HomeAssistant) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    source = await manager.async_create_asset(
+        name="Panel",
+        asset_type="panel",
+        code="PANEL-01",
+        area_id=None,
+        capabilities=[],
+    )
+    target = await manager.async_create_asset(
+        name="Socket",
+        asset_type="socket",
+        code="SOCK-01",
+        area_id=None,
+        capabilities=[],
+    )
+
+    await _assert_storage_failure_is_atomic(
+        hass,
+        manager,
+        lambda: manager.async_add_relation(
+            source_asset_id=source.id,
+            relation_type="feeds",
+            target_asset_id=target.id,
+        ),
+    )
+
+
+async def test_remove_relation_storage_failure_is_atomic(hass: HomeAssistant) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    source = await manager.async_create_asset(
+        name="Panel",
+        asset_type="panel",
+        code="PANEL-01",
+        area_id=None,
+        capabilities=[],
+    )
+    target = await manager.async_create_asset(
+        name="Socket",
+        asset_type="socket",
+        code="SOCK-01",
+        area_id=None,
+        capabilities=[],
+    )
+    relation = await manager.async_add_relation(
+        source_asset_id=source.id,
+        relation_type="feeds",
+        target_asset_id=target.id,
+    )
+
+    await _assert_storage_failure_is_atomic(
+        hass,
+        manager,
+        lambda: manager.async_remove_relation(relation.id),
+    )
+
+
+async def test_set_binding_storage_failure_is_atomic(hass: HomeAssistant) -> None:
+    hass.states.async_set("switch.backend", "off")
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    asset = await manager.async_create_asset(
+        name="Logical light",
+        asset_type="light_point",
+        code="LGT-01",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+
+    await _assert_storage_failure_is_atomic(
+        hass,
+        manager,
+        lambda: manager.async_set_binding(
+            asset_id=asset.id,
+            capability="on_off",
+            entity_id="switch.backend",
+            role="primary",
+        ),
+    )
+
+
+async def test_replace_binding_storage_failure_is_atomic(hass: HomeAssistant) -> None:
+    hass.states.async_set("switch.backend_a", "off")
+    hass.states.async_set("switch.backend_b", "off")
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    asset = await manager.async_create_asset(
+        name="Logical light",
+        asset_type="light_point",
+        code="LGT-01",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    original = await manager.async_set_binding(
+        asset_id=asset.id,
+        capability="on_off",
+        entity_id="switch.backend_a",
+        role="primary",
+    )
+
+    await _assert_storage_failure_is_atomic(
+        hass,
+        manager,
+        lambda: manager.async_set_binding(
+            asset_id=asset.id,
+            capability="on_off",
+            entity_id="switch.backend_b",
+            role="primary",
+        ),
+    )
+
+    assert manager.registry.bindings[original.id] == original
+
+
+async def test_remove_binding_storage_failure_is_atomic(hass: HomeAssistant) -> None:
+    hass.states.async_set("switch.backend", "off")
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    asset = await manager.async_create_asset(
+        name="Logical light",
+        asset_type="light_point",
+        code="LGT-01",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    binding = await manager.async_set_binding(
+        asset_id=asset.id,
+        capability="on_off",
+        entity_id="switch.backend",
+        role="primary",
+    )
+
+    await _assert_storage_failure_is_atomic(
+        hass,
+        manager,
+        lambda: manager.async_remove_binding(binding.id),
+    )
+
+
+async def test_set_representation_storage_failure_is_atomic(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    asset = await manager.async_create_asset(
+        name="Logical light",
+        asset_type="light_point",
+        code="LGT-01",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+
+    await _assert_storage_failure_is_atomic(
+        hass,
+        manager,
+        lambda: manager.async_set_representation(
+            asset_id=asset.id,
+            platform="light",
+        ),
+    )
+
+
+async def test_remove_representation_storage_failure_is_atomic(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    asset = await manager.async_create_asset(
+        name="Logical light",
+        asset_type="light_point",
+        code="LGT-01",
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await manager.async_set_representation(
+        asset_id=asset.id,
+        platform="light",
+    )
+
+    await _assert_storage_failure_is_atomic(
+        hass,
+        manager,
+        lambda: manager.async_remove_representation(asset.id),
+    )
+
+
+async def test_commit_persists_before_live_adoption_and_signal(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    asset = await manager.async_create_asset(
+        name="Original",
+        asset_type="socket",
+        code="SOCK-01",
+        area_id=None,
+        capabilities=[],
+    )
+
+    original_registry = manager.registry
+    baseline = manager.registry.to_dict()
+    notifications: list[None] = []
+    unsubscribe = async_dispatcher_connect(
+        hass,
+        SIGNAL_REGISTRY_CHANGED,
+        lambda: notifications.append(None),
+    )
+
+    async def assert_precommit_state(staged: object) -> None:
+        assert manager.registry is original_registry
+        assert manager.registry.to_dict() == baseline
+        assert notifications == []
+        assert staged is not manager.registry
+
+    manager._store.async_save = AsyncMock(side_effect=assert_precommit_state)
+
+    try:
+        updated = await manager.async_update_asset(
+            asset_id=asset.id,
+            name="Committed",
+            asset_type="socket",
+            code="SOCK-02",
+            area_id=None,
+            capabilities=[],
+        )
+        await hass.async_block_till_done()
+
+        assert manager.registry is original_registry
+        assert manager.registry.get_asset(asset.id) == updated
+        assert manager.registry.to_dict() != baseline
+        assert notifications == [None]
+    finally:
+        unsubscribe()

--- a/tests/test_store_failure_propagation.py
+++ b/tests/test_store_failure_propagation.py
@@ -43,19 +43,21 @@ async def test_underlying_store_write_failure_does_not_commit(
         # Inject the failure below _FailFastStore._async_write_data(). This
         # exercises the exact boundary where BindHome translates the errors
         # Home Assistant's Store would otherwise catch and log.
-        with patch.object(Store, "_async_write_data", new=base_write):
-            with pytest.raises(
+        with (
+            patch.object(Store, "_async_write_data", new=base_write),
+            pytest.raises(
                 BindHomeStoreError,
                 match="Failed to persist BindHome registry",
-            ):
-                await manager.async_update_asset(
-                    asset_id=asset.id,
-                    name="Should not commit",
-                    asset_type="socket",
-                    code="SOCK-02",
-                    area_id=None,
-                    capabilities=[],
-                )
+            ),
+        ):
+            await manager.async_update_asset(
+                asset_id=asset.id,
+                name="Should not commit",
+                asset_type="socket",
+                code="SOCK-02",
+                area_id=None,
+                capabilities=[],
+            )
 
         base_write.assert_awaited_once()
         await hass.async_block_till_done()

--- a/tests/test_store_failure_propagation.py
+++ b/tests/test_store_failure_propagation.py
@@ -37,15 +37,13 @@ async def test_underlying_store_write_failure_does_not_commit(
         lambda: notifications.append(None),
     )
 
+    base_write = AsyncMock(side_effect=WriteError("disk full"))
+
     try:
         # Inject the failure below _FailFastStore._async_write_data(). This
         # exercises the exact boundary where BindHome translates the errors
         # Home Assistant's Store would otherwise catch and log.
-        with patch.object(
-            Store,
-            "_async_write_data",
-            new=AsyncMock(side_effect=WriteError("disk full")),
-        ):
+        with patch.object(Store, "_async_write_data", new=base_write):
             with pytest.raises(
                 BindHomeStoreError,
                 match="Failed to persist BindHome registry",
@@ -59,6 +57,7 @@ async def test_underlying_store_write_failure_does_not_commit(
                     capabilities=[],
                 )
 
+        base_write.assert_awaited_once()
         await hass.async_block_till_done()
 
         assert manager.registry is original_registry

--- a/tests/test_store_failure_propagation.py
+++ b/tests/test_store_failure_propagation.py
@@ -1,10 +1,11 @@
 """Tests for fail-fast BindHome storage writes."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.storage import Store
 from homeassistant.util.file import WriteError
 
 from custom_components.bindhome.const import SIGNAL_REGISTRY_CHANGED
@@ -36,23 +37,27 @@ async def test_underlying_store_write_failure_does_not_commit(
         lambda: notifications.append(None),
     )
 
-    manager._store._store._write_prepared_data = MagicMock(
-        side_effect=WriteError("disk full"),
-    )
-
     try:
-        with pytest.raises(
-            BindHomeStoreError,
-            match="Failed to persist BindHome registry",
+        # Inject the failure below _FailFastStore._async_write_data(). This
+        # exercises the exact boundary where BindHome translates the errors
+        # Home Assistant's Store would otherwise catch and log.
+        with patch.object(
+            Store,
+            "_async_write_data",
+            new=AsyncMock(side_effect=WriteError("disk full")),
         ):
-            await manager.async_update_asset(
-                asset_id=asset.id,
-                name="Should not commit",
-                asset_type="socket",
-                code="SOCK-02",
-                area_id=None,
-                capabilities=[],
-            )
+            with pytest.raises(
+                BindHomeStoreError,
+                match="Failed to persist BindHome registry",
+            ):
+                await manager.async_update_asset(
+                    asset_id=asset.id,
+                    name="Should not commit",
+                    asset_type="socket",
+                    code="SOCK-02",
+                    area_id=None,
+                    capabilities=[],
+                )
 
         await hass.async_block_till_done()
 

--- a/tests/test_store_failure_propagation.py
+++ b/tests/test_store_failure_propagation.py
@@ -1,0 +1,67 @@
+"""Tests for fail-fast BindHome storage writes."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.util.file import WriteError
+
+from custom_components.bindhome.const import SIGNAL_REGISTRY_CHANGED
+from custom_components.bindhome.manager import BindHomeManager
+from custom_components.bindhome.store import BindHomeStoreError
+
+
+async def test_underlying_store_write_failure_does_not_commit(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    asset = await manager.async_create_asset(
+        name="Original",
+        asset_type="socket",
+        code="SOCK-01",
+        area_id=None,
+        capabilities=[],
+    )
+
+    original_registry = manager.registry
+    baseline = manager.registry.to_dict()
+    assert manager._store._store._atomic_writes is True
+
+    notifications: list[None] = []
+    unsubscribe = async_dispatcher_connect(
+        hass,
+        SIGNAL_REGISTRY_CHANGED,
+        lambda: notifications.append(None),
+    )
+
+    manager._store._store._write_prepared_data = MagicMock(
+        side_effect=WriteError("disk full"),
+    )
+
+    try:
+        with pytest.raises(
+            BindHomeStoreError,
+            match="Failed to persist BindHome registry",
+        ):
+            await manager.async_update_asset(
+                asset_id=asset.id,
+                name="Should not commit",
+                asset_type="socket",
+                code="SOCK-02",
+                area_id=None,
+                capabilities=[],
+            )
+
+        await hass.async_block_till_done()
+
+        assert manager.registry is original_registry
+        assert manager.registry.to_dict() == baseline
+        assert notifications == []
+
+        reloaded = BindHomeManager(hass)
+        await reloaded.async_load()
+        assert reloaded.registry.to_dict() == baseline
+    finally:
+        unsubscribe()


### PR DESCRIPTION
## P1 — Reliability & Release Foundation

This starts P1 by making every `BindHomeManager` mutation failure-atomic with respect to persistent storage.

### Transaction contract

Every mutation now runs under the existing mutation lock and follows the same sequence:

1. clone the live Registry into an isolated staged Registry;
2. apply validation and mutation only to staged state;
3. persist staged state;
4. only after a successful save, adopt staged contents into the existing live Registry object;
5. emit `SIGNAL_REGISTRY_CHANGED` only after commit.

The live `BindHomeRegistry` identity is preserved through the existing in-place `clear()/update()` adoption strategy.

### Covered mutations

- create Asset;
- bulk create Assets;
- update Asset;
- delete Asset;
- create/delete Relation;
- set/delete Binding;
- set/delete Representation.

Binding target/cycle validation now reads from the staged Registry so the whole mutation path is isolated from live RAM.

### Storage failure semantics

Home Assistant's public `Store.async_save()` normally catches `WriteError`/serialization failures and logs them instead of propagating them. That behavior is not sufficient for BindHome's commit boundary: the manager could otherwise publish staged RAM after the underlying disk write had failed.

`BindHomeStore` therefore uses a small fail-fast `Store` subclass that converts underlying write/serialization exceptions into `BindHomeStoreError`, allowing `BindHomeManager` to abort before adoption or notification. The store is also configured with `atomic_writes=True` for fsync-backed mission-critical persistence.

### Failure-atomicity tests

Adds storage-failure coverage for every requested mutation, including both create and replacement paths of `set_binding()`.

Each manager failure test asserts:

- persistence was attempted exactly once;
- the live Registry object is unchanged;
- serialized RAM state remains equal to the pre-mutation snapshot;
- no `SIGNAL_REGISTRY_CHANGED` notification is emitted;
- reloading through a fresh `BindHomeManager` returns the pre-mutation persisted Registry.

An additional ordering test asserts that while staged persistence is in progress, live RAM is still the pre-mutation state and no signal has fired; adoption and signal occur only after save completes.

A lower-level integration test forces Home Assistant's underlying prepared-file write to raise `WriteError` and verifies that BindHome surfaces `BindHomeStoreError`, keeps live RAM unchanged, emits no signal, and reloads the previous disk state.

### Non-goals

No UX, WebSocket contract, services contract, domain model, Registry schema, or representation semantics are expanded in this PR.