### PR TITLE
refactor: fail closed on unsafe registry loads

### DIFF
--- a/custom_components/bindhome/__init__.py
+++ b/custom_components/bindhome/__init__.py
@@ -14,7 +14,7 @@ from .manager import BindHomeManager
 from .panel import async_register_panel, async_unregister_panel
 from .representation import implemented_platforms
 from .services import async_register_services
-from .store import BindHomeStoreLoadError
+from .store import BindHomeStoreError
 from .websocket import async_register_websocket_commands
 
 type BindHomeConfigEntry = ConfigEntry[BindHomeManager]
@@ -35,7 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BindHomeConfigEntry) -> 
     manager = BindHomeManager(hass)
     try:
         await manager.async_load()
-    except BindHomeStoreLoadError as err:
+    except BindHomeStoreError as err:
         raise ConfigEntryError(str(err)) from err
 
     entry.runtime_data = manager

--- a/custom_components/bindhome/__init__.py
+++ b/custom_components/bindhome/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
@@ -13,6 +14,7 @@ from .manager import BindHomeManager
 from .panel import async_register_panel, async_unregister_panel
 from .representation import implemented_platforms
 from .services import async_register_services
+from .store import BindHomeStoreLoadError
 from .websocket import async_register_websocket_commands
 
 type BindHomeConfigEntry = ConfigEntry[BindHomeManager]
@@ -31,7 +33,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: BindHomeConfigEntry) -> bool:
     """Set up BindHome from a config entry."""
     manager = BindHomeManager(hass)
-    await manager.async_load()
+    try:
+        await manager.async_load()
+    except BindHomeStoreLoadError as err:
+        raise ConfigEntryError(str(err)) from err
+
     entry.runtime_data = manager
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     await async_register_panel(hass)

--- a/custom_components/bindhome/store.py
+++ b/custom_components/bindhome/store.py
@@ -2,19 +2,33 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, UnsupportedStorageVersionError
 from homeassistant.helpers.storage import Store
 from homeassistant.util import json as json_util
 from homeassistant.util.file import WriteError
 
 from .const import STORAGE_KEY, STORAGE_VERSION
-from .registry import BindHomeRegistry
+from .registry import BindHomeRegistry, RegistryValidationError
 
 
 class BindHomeStoreError(RuntimeError):
-    """Raised when Home Assistant cannot persist the BindHome registry."""
+    """Base error for BindHome persistent storage failures."""
+
+
+class BindHomeStoreLoadError(BindHomeStoreError):
+    """Raised when persisted BindHome state cannot be loaded safely."""
+
+
+class BindHomeStoreCorruptionError(BindHomeStoreLoadError):
+    """Raised when Home Assistant moved corrupt BindHome storage aside."""
+
+
+class BindHomeStoreVersionError(BindHomeStoreLoadError):
+    """Raised when the Home Assistant storage envelope is too new."""
 
 
 class _FailFastStore(Store[dict[str, Any]]):
@@ -31,6 +45,7 @@ class BindHomeStore:
     """Persist the BindHome registry using Home Assistant storage."""
 
     def __init__(self, hass: HomeAssistant) -> None:
+        self._hass = hass
         self._store: Store[dict[str, Any]] = _FailFastStore(
             hass,
             STORAGE_VERSION,
@@ -38,9 +53,52 @@ class BindHomeStore:
             atomic_writes=True,
         )
 
+    async def _async_path_exists(self) -> bool:
+        """Return whether the managed Home Assistant storage file exists."""
+        return await self._hass.async_add_executor_job(os.path.isfile, self._store.path)
+
     async def async_load(self) -> BindHomeRegistry:
-        """Load the registry from Home Assistant storage."""
-        return BindHomeRegistry.from_dict(await self._store.async_load())
+        """Load persisted registry state without silently discarding failures."""
+        existed_before = await self._async_path_exists()
+
+        try:
+            data = await self._store.async_load()
+        except UnsupportedStorageVersionError as err:
+            raise BindHomeStoreVersionError(
+                "BindHome storage was written by a newer incompatible version"
+            ) from err
+        except HomeAssistantError as err:
+            raise BindHomeStoreLoadError(
+                "Home Assistant could not read BindHome storage"
+            ) from err
+
+        if data is None:
+            if not existed_before:
+                return BindHomeRegistry()
+
+            if not await self._async_path_exists():
+                raise BindHomeStoreCorruptionError(
+                    "BindHome storage is corrupt and Home Assistant moved it aside; "
+                    "restore the registry from a backup before continuing"
+                )
+
+            raise BindHomeStoreLoadError(
+                "BindHome storage exists but did not contain a readable registry"
+            )
+
+        try:
+            registry = BindHomeRegistry.from_dict(data)
+        except RegistryValidationError as err:
+            raise BindHomeStoreLoadError(
+                f"Persisted BindHome registry is invalid: {err}"
+            ) from err
+
+        # Persist the already-supported legacy in-memory migration once so
+        # future starts load the canonical explicit Representation form.
+        if "schema_version" not in data or "representations" not in data:
+            await self.async_save(registry)
+
+        return registry
 
     async def async_save(self, registry: BindHomeRegistry) -> None:
         """Persist the registry immediately or raise on storage failure."""

--- a/custom_components/bindhome/store.py
+++ b/custom_components/bindhome/store.py
@@ -28,7 +28,7 @@ class BindHomeStoreCorruptionError(BindHomeStoreLoadError):
 
 
 class BindHomeStoreVersionError(BindHomeStoreLoadError):
-    """Raised when the Home Assistant storage envelope is too new."""
+    """Raised when the Home Assistant storage envelope is incompatible."""
 
 
 class _FailFastStore(Store[dict[str, Any]]):
@@ -67,7 +67,11 @@ class BindHomeStore:
             raise BindHomeStoreVersionError(
                 "BindHome storage was written by a newer incompatible version"
             ) from err
-        except HomeAssistantError as err:
+        except NotImplementedError as err:
+            raise BindHomeStoreVersionError(
+                "BindHome storage uses an unsupported older storage version"
+            ) from err
+        except (HomeAssistantError, KeyError, TypeError) as err:
             raise BindHomeStoreLoadError(
                 "Home Assistant could not read BindHome storage"
             ) from err

--- a/tests/test_store_recovery.py
+++ b/tests/test_store_recovery.py
@@ -1,0 +1,178 @@
+"""Tests for fail-closed BindHome registry loading and recovery."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError, HomeAssistantError
+
+from custom_components.bindhome import async_setup_entry
+from custom_components.bindhome.registry import BindHomeRegistry
+from custom_components.bindhome.store import (
+    BindHomeStore,
+    BindHomeStoreCorruptionError,
+    BindHomeStoreError,
+    BindHomeStoreLoadError,
+)
+
+
+async def test_missing_storage_loads_empty_registry(hass: HomeAssistant) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(return_value=False)
+    store._store.async_load = AsyncMock(return_value=None)
+
+    registry = await store.async_load()
+
+    assert registry.to_dict() == BindHomeRegistry().to_dict()
+    store._async_path_exists.assert_awaited_once()
+    store._store.async_load.assert_awaited_once()
+
+
+async def test_corrupt_storage_does_not_become_empty_registry(
+    hass: HomeAssistant,
+) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(side_effect=[True, False])
+    store._store.async_load = AsyncMock(return_value=None)
+
+    with pytest.raises(
+        BindHomeStoreCorruptionError,
+        match="Home Assistant moved it aside",
+    ):
+        await store.async_load()
+
+    assert store._async_path_exists.await_count == 2
+
+
+async def test_existing_unreadable_storage_fails_closed(hass: HomeAssistant) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(side_effect=[True, True])
+    store._store.async_load = AsyncMock(return_value=None)
+
+    with pytest.raises(
+        BindHomeStoreLoadError,
+        match="did not contain a readable registry",
+    ):
+        await store.async_load()
+
+
+async def test_home_assistant_load_failure_is_surfaced(hass: HomeAssistant) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(return_value=True)
+    store._store.async_load = AsyncMock(
+        side_effect=HomeAssistantError("cannot read storage")
+    )
+
+    with pytest.raises(
+        BindHomeStoreLoadError,
+        match="Home Assistant could not read BindHome storage",
+    ):
+        await store.async_load()
+
+
+async def test_future_registry_schema_is_rejected_without_rewrite(
+    hass: HomeAssistant,
+) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(return_value=True)
+    store._store.async_load = AsyncMock(
+        return_value={
+            "schema_version": 999,
+            "assets": [],
+            "relations": [],
+            "bindings": [],
+            "representations": [],
+        }
+    )
+    store.async_save = AsyncMock()
+
+    with pytest.raises(
+        BindHomeStoreLoadError,
+        match="Unsupported registry schema version: 999",
+    ):
+        await store.async_load()
+
+    store.async_save.assert_not_awaited()
+
+
+async def test_legacy_representation_migration_is_persisted_once(
+    hass: HomeAssistant,
+) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(return_value=True)
+    store._store.async_load = AsyncMock(
+        return_value={
+            "schema_version": 1,
+            "assets": [
+                {
+                    "id": "legacy-light",
+                    "name": "Legacy logical light",
+                    "asset_type": "light_point",
+                    "capabilities": ["on_off"],
+                }
+            ],
+            "relations": [],
+            "bindings": [],
+        }
+    )
+    store.async_save = AsyncMock()
+
+    registry = await store.async_load()
+
+    representation = registry.get_representation("legacy-light")
+    assert representation is not None
+    assert representation.platform == "light"
+    store.async_save.assert_awaited_once_with(registry)
+
+
+async def test_canonical_registry_is_not_rewritten_on_load(
+    hass: HomeAssistant,
+) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(return_value=True)
+    store._store.async_load = AsyncMock(
+        return_value={
+            "schema_version": 1,
+            "assets": [],
+            "relations": [],
+            "bindings": [],
+            "representations": [],
+        }
+    )
+    store.async_save = AsyncMock()
+
+    registry = await store.async_load()
+
+    assert registry.to_dict() == BindHomeRegistry().to_dict()
+    store.async_save.assert_not_awaited()
+
+
+async def test_migration_write_failure_aborts_load(hass: HomeAssistant) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(return_value=True)
+    store._store.async_load = AsyncMock(
+        return_value={
+            "schema_version": 1,
+            "assets": [],
+            "relations": [],
+            "bindings": [],
+        }
+    )
+    store.async_save = AsyncMock(side_effect=BindHomeStoreError("disk full"))
+
+    with pytest.raises(BindHomeStoreError, match="disk full"):
+        await store.async_load()
+
+
+async def test_setup_entry_reports_storage_failure_as_config_entry_error(
+    hass: HomeAssistant,
+) -> None:
+    load = AsyncMock(side_effect=BindHomeStoreLoadError("registry unsafe"))
+
+    with (
+        patch("custom_components.bindhome.BindHomeManager.async_load", new=load),
+        pytest.raises(ConfigEntryError, match="registry unsafe"),
+    ):
+        await async_setup_entry(hass, MagicMock())
+
+    load.assert_awaited_once()

--- a/tests/test_store_recovery.py
+++ b/tests/test_store_recovery.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError, HomeAssistantError
+from homeassistant.exceptions import (
+    ConfigEntryError,
+    HomeAssistantError,
+    UnsupportedStorageVersionError,
+)
 
 from custom_components.bindhome import async_setup_entry
 from custom_components.bindhome.registry import BindHomeRegistry
@@ -13,6 +17,7 @@ from custom_components.bindhome.store import (
     BindHomeStoreCorruptionError,
     BindHomeStoreError,
     BindHomeStoreLoadError,
+    BindHomeStoreVersionError,
 )
 
 
@@ -62,6 +67,46 @@ async def test_home_assistant_load_failure_is_surfaced(hass: HomeAssistant) -> N
     store._store.async_load = AsyncMock(
         side_effect=HomeAssistantError("cannot read storage")
     )
+
+    with pytest.raises(
+        BindHomeStoreLoadError,
+        match="Home Assistant could not read BindHome storage",
+    ):
+        await store.async_load()
+
+
+async def test_newer_storage_envelope_is_rejected(hass: HomeAssistant) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(return_value=True)
+    store._store.async_load = AsyncMock(
+        side_effect=UnsupportedStorageVersionError("bindhome.registry", 2, 1)
+    )
+
+    with pytest.raises(
+        BindHomeStoreVersionError,
+        match="newer incompatible version",
+    ):
+        await store.async_load()
+
+
+async def test_older_unmigratable_storage_envelope_is_rejected(
+    hass: HomeAssistant,
+) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(return_value=True)
+    store._store.async_load = AsyncMock(side_effect=NotImplementedError)
+
+    with pytest.raises(
+        BindHomeStoreVersionError,
+        match="unsupported older storage version",
+    ):
+        await store.async_load()
+
+
+async def test_malformed_storage_envelope_is_surfaced(hass: HomeAssistant) -> None:
+    store = BindHomeStore(hass)
+    store._async_path_exists = AsyncMock(return_value=True)
+    store._store.async_load = AsyncMock(side_effect=KeyError("version"))
 
     with pytest.raises(
         BindHomeStoreLoadError,


### PR DESCRIPTION
## P1 — Reliability & Release Foundation

This continues P1 by hardening BindHome startup and persisted-registry recovery semantics.

### Load contract

BindHome now distinguishes between:

- no BindHome storage file: start with a new empty Registry;
- corrupt storage moved aside by Home Assistant: fail setup instead of silently starting empty;
- an existing storage file that yields no readable payload: fail setup;
- Home Assistant storage read errors: surface a BindHome load error;
- unsupported/future Registry schema: reject without rewriting persisted data.

`async_setup_entry()` converts BindHome storage failures into `ConfigEntryError`, so an unsafe Registry is never published through `entry.runtime_data` and the integration does not continue with an accidental empty state.

### Legacy migration durability

The already-supported legacy migration for pre-Representation registries previously happened only in memory. When a readable legacy payload is detected (missing `schema_version` and/or `representations`), BindHome now persists the canonical Registry once after successful validation. Migration writes still use the fail-fast atomic Store from #17; a failed migration write aborts setup.

### Tests

Adds regression coverage for:

- missing storage -> empty Registry;
- corrupt storage -> explicit failure;
- existing unreadable storage -> explicit failure;
- Home Assistant read failure propagation;
- future Registry schema rejection with no rewrite;
- durable legacy Representation migration;
- canonical Registry loads without unnecessary rewrite;
- migration write failure aborting load;
- config-entry setup surfacing storage failure as `ConfigEntryError`.

### Non-goals

No UX changes, no new Asset/Binding/Relation/Representation semantics, no forced schema-version bump, and no manual manipulation of Home Assistant `.storage` files.