### PR TITLE
feat: add transactional registry backup and restore

### DIFF
--- a/custom_components/bindhome/__init__.py
+++ b/custom_components/bindhome/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
+from .backup_websocket import async_register_backup_websocket_commands
 from .const import DOMAIN
 from .manager import BindHomeManager
 from .panel import async_register_panel, async_unregister_panel
@@ -27,6 +28,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up BindHome and register service actions."""
     async_register_services(hass)
     async_register_websocket_commands(hass)
+    async_register_backup_websocket_commands(hass)
     return True
 
 

--- a/custom_components/bindhome/backup.py
+++ b/custom_components/bindhome/backup.py
@@ -1,0 +1,69 @@
+"""Stable BindHome Registry backup and restore contract."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .registry import BindHomeRegistry, RegistryValidationError
+
+if TYPE_CHECKING:
+    from .manager import BindHomeManager
+
+BACKUP_FORMAT = "bindhome.registry"
+BACKUP_FORMAT_VERSION = 1
+
+
+class BackupValidationError(RegistryValidationError):
+    """Raised when a BindHome backup cannot be restored safely."""
+
+
+def export_registry_backup(registry: BindHomeRegistry) -> dict[str, Any]:
+    """Return a deterministic, versioned backup envelope."""
+    return {
+        "format": BACKUP_FORMAT,
+        "format_version": BACKUP_FORMAT_VERSION,
+        "registry": registry.to_dict(),
+    }
+
+
+def parse_registry_backup(data: object) -> BindHomeRegistry:
+    """Validate a backup envelope and return its isolated Registry."""
+    if not isinstance(data, dict):
+        raise BackupValidationError("BindHome backup must be a dictionary")
+
+    backup_format = data.get("format")
+    if backup_format != BACKUP_FORMAT:
+        raise BackupValidationError(
+            f"Unsupported BindHome backup format: {backup_format}"
+        )
+
+    format_version = data.get("format_version")
+    if format_version != BACKUP_FORMAT_VERSION:
+        raise BackupValidationError(
+            f"Unsupported BindHome backup format version: {format_version}"
+        )
+
+    if "registry" not in data:
+        raise BackupValidationError("BindHome backup is missing registry")
+
+    registry_data = data["registry"]
+    if not isinstance(registry_data, dict):
+        raise BackupValidationError("BindHome backup registry must be a dictionary")
+
+    try:
+        return BindHomeRegistry.from_dict(registry_data)
+    except RegistryValidationError as err:
+        raise BackupValidationError(f"Invalid BindHome backup registry: {err}") from err
+
+
+async def async_restore_registry_backup(
+    manager: BindHomeManager,
+    data: object,
+) -> BindHomeRegistry:
+    """Validate and atomically replace the live Registry from a backup."""
+    staged = parse_registry_backup(data)
+
+    async with manager._mutation_lock:
+        await manager._async_commit_staged_registry(staged)
+
+    return manager.registry

--- a/custom_components/bindhome/backup_websocket.py
+++ b/custom_components/bindhome/backup_websocket.py
@@ -75,7 +75,10 @@ async def ws_backup_restore(
 ) -> None:
     """Validate and atomically restore the Registry from a backup."""
     try:
-        registry = await async_restore_registry_backup(_get_manager(hass), msg["backup"])
+        registry = await async_restore_registry_backup(
+            _get_manager(hass),
+            msg["backup"],
+        )
     except BackupValidationError as err:
         connection.send_error(msg["id"], ERR_INVALID_FORMAT, str(err))
         return

--- a/custom_components/bindhome/backup_websocket.py
+++ b/custom_components/bindhome/backup_websocket.py
@@ -1,0 +1,101 @@
+"""Administrative WebSocket API for BindHome Registry backup and restore."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.components import websocket_api
+from homeassistant.components.websocket_api.connection import ActiveConnection
+from homeassistant.components.websocket_api.const import ERR_INVALID_FORMAT
+from homeassistant.components.websocket_api.decorators import (
+    async_response,
+    require_admin,
+    websocket_command,
+)
+from homeassistant.core import HomeAssistant
+
+from .backup import (
+    BackupValidationError,
+    async_restore_registry_backup,
+    export_registry_backup,
+)
+from .const import DOMAIN
+from .manager import BindHomeManager
+from .registry import RegistryValidationError
+from .store import BindHomeStoreError
+
+WS_BACKUP_EXPORT = f"{DOMAIN}/backup/export"
+WS_BACKUP_RESTORE = f"{DOMAIN}/backup/restore"
+
+
+def _get_manager(hass: HomeAssistant) -> BindHomeManager:
+    """Return the loaded BindHome manager."""
+    entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state is config_entries.ConfigEntryState.LOADED
+    ]
+    if not entries:
+        raise RegistryValidationError("BindHome is not configured or loaded")
+    return cast(BindHomeManager, entries[0].runtime_data)
+
+
+@require_admin
+@websocket_command({vol.Required("type"): WS_BACKUP_EXPORT})
+@async_response
+async def ws_backup_export(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Export the complete Registry in the stable backup envelope."""
+    try:
+        backup = export_registry_backup(_get_manager(hass).registry)
+    except RegistryValidationError as err:
+        connection.send_error(msg["id"], ERR_INVALID_FORMAT, str(err))
+        return
+
+    connection.send_result(msg["id"], {"backup": backup})
+
+
+@require_admin
+@websocket_command(
+    {
+        vol.Required("type"): WS_BACKUP_RESTORE,
+        vol.Required("backup"): dict,
+    }
+)
+@async_response
+async def ws_backup_restore(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Validate and atomically restore the Registry from a backup."""
+    try:
+        registry = await async_restore_registry_backup(_get_manager(hass), msg["backup"])
+    except BackupValidationError as err:
+        connection.send_error(msg["id"], ERR_INVALID_FORMAT, str(err))
+        return
+    except BindHomeStoreError as err:
+        connection.send_error(msg["id"], "storage_error", str(err))
+        return
+    except RegistryValidationError as err:
+        connection.send_error(msg["id"], ERR_INVALID_FORMAT, str(err))
+        return
+
+    connection.send_result(
+        msg["id"],
+        {
+            "restored": True,
+            "registry": registry.to_dict(),
+        },
+    )
+
+
+def async_register_backup_websocket_commands(hass: HomeAssistant) -> None:
+    """Register BindHome backup WebSocket commands."""
+    websocket_api.async_register_command(hass, ws_backup_export)
+    websocket_api.async_register_command(hass, ws_backup_restore)

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,52 @@
+# Registry backup and restore
+
+BindHome exposes an administrator-only WebSocket contract for exporting and restoring the complete logical Registry without reading or editing Home Assistant `.storage` files directly.
+
+## Backup envelope
+
+`bindhome/backup/export` returns a versioned envelope:
+
+```json
+{
+  "backup": {
+    "format": "bindhome.registry",
+    "format_version": 1,
+    "registry": {
+      "schema_version": 1,
+      "assets": [],
+      "relations": [],
+      "bindings": [],
+      "representations": []
+    }
+  }
+}
+```
+
+The backup format version and Registry schema version are independent. The outer version controls the backup transport contract. The inner `schema_version` controls the persisted BindHome domain model.
+
+The export contains no timestamp or environment-specific metadata, so exporting the same Registry twice produces the same payload.
+
+## Restore contract
+
+`bindhome/backup/restore` accepts the `backup` object returned by export.
+
+Restore is a full Registry replacement, not a merge. BindHome:
+
+1. validates the backup envelope and its version;
+2. deserializes and validates the complete Registry into isolated staged state;
+3. acquires the manager mutation lock;
+4. persists the staged Registry using the fail-fast atomic Store;
+5. only after persistence succeeds, adopts the staged contents into the existing live Registry object;
+6. emits `SIGNAL_REGISTRY_CHANGED` after commit.
+
+A malformed backup, unsupported backup version, unsupported Registry schema, or Registry validation failure is rejected before persistence is attempted.
+
+A persistence failure leaves the live Registry unchanged and emits no Registry-changed signal.
+
+## Scope and safety
+
+Both commands require a Home Assistant administrator.
+
+A backup may contain Home Assistant entity references that have since become stale. BindHome preserves those references during restore just as it does during normal persisted startup; runtime resolution reports stale or unavailable targets separately.
+
+Do not manipulate Home Assistant `.storage` files to create or restore a BindHome backup. Use this API or a future UX built on top of it.

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,186 @@
+"""Tests for BindHome Registry backup and restore."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from custom_components.bindhome.backup import (
+    BACKUP_FORMAT,
+    BACKUP_FORMAT_VERSION,
+    BackupValidationError,
+    async_restore_registry_backup,
+    export_registry_backup,
+    parse_registry_backup,
+)
+from custom_components.bindhome.const import SIGNAL_REGISTRY_CHANGED
+from custom_components.bindhome.manager import BindHomeManager
+from custom_components.bindhome.models import Asset
+from custom_components.bindhome.registry import BindHomeRegistry
+from custom_components.bindhome.store import BindHomeStoreError
+
+
+def _registry(name: str, code: str) -> BindHomeRegistry:
+    registry = BindHomeRegistry()
+    registry.add_asset(
+        Asset.create(
+            name=name,
+            asset_type="socket",
+            code=code,
+            capabilities=["on_off"],
+        )
+    )
+    return registry
+
+
+def test_export_uses_stable_versioned_envelope() -> None:
+    registry = _registry("Workshop socket", "SOCK-01")
+
+    first = export_registry_backup(registry)
+    second = export_registry_backup(registry)
+
+    assert first == second
+    assert first == {
+        "format": BACKUP_FORMAT,
+        "format_version": BACKUP_FORMAT_VERSION,
+        "registry": registry.to_dict(),
+    }
+
+
+def test_backup_round_trip_restores_registry_exactly() -> None:
+    registry = _registry("Workshop socket", "SOCK-01")
+
+    restored = parse_registry_backup(export_registry_backup(registry))
+
+    assert restored is not registry
+    assert restored.to_dict() == registry.to_dict()
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ("not-a-dict", "backup must be a dictionary"),
+        ({"format": "other", "format_version": 1, "registry": {}}, "backup format"),
+        (
+            {"format": BACKUP_FORMAT, "format_version": 999, "registry": {}},
+            "format version",
+        ),
+        (
+            {"format": BACKUP_FORMAT, "format_version": BACKUP_FORMAT_VERSION},
+            "missing registry",
+        ),
+        (
+            {
+                "format": BACKUP_FORMAT,
+                "format_version": BACKUP_FORMAT_VERSION,
+                "registry": "invalid",
+            },
+            "registry must be a dictionary",
+        ),
+    ],
+)
+def test_backup_envelope_validation(payload: object, message: str) -> None:
+    with pytest.raises(BackupValidationError, match=message):
+        parse_registry_backup(payload)
+
+
+def test_invalid_registry_payload_is_rejected() -> None:
+    payload = {
+        "format": BACKUP_FORMAT,
+        "format_version": BACKUP_FORMAT_VERSION,
+        "registry": {
+            "schema_version": 999,
+            "assets": [],
+            "relations": [],
+            "bindings": [],
+            "representations": [],
+        },
+    }
+
+    with pytest.raises(
+        BackupValidationError,
+        match="Unsupported registry schema version: 999",
+    ):
+        parse_registry_backup(payload)
+
+
+async def test_restore_persists_before_adoption_and_preserves_identity(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    original = _registry("Old socket", "OLD-01")
+    manager._adopt_staged_registry(original)
+    original_registry = manager.registry
+    replacement = _registry("Restored socket", "RESTORE-01")
+    backup = export_registry_backup(replacement)
+
+    notifications: list[None] = []
+    unsubscribe = async_dispatcher_connect(
+        hass,
+        SIGNAL_REGISTRY_CHANGED,
+        lambda: notifications.append(None),
+    )
+
+    async def save(staged: BindHomeRegistry) -> None:
+        assert manager.registry is original_registry
+        assert manager.registry.to_dict() == original.to_dict()
+        assert notifications == []
+        assert staged.to_dict() == replacement.to_dict()
+
+    manager._store.async_save = AsyncMock(side_effect=save)
+
+    try:
+        restored = await async_restore_registry_backup(manager, backup)
+    finally:
+        unsubscribe()
+
+    manager._store.async_save.assert_awaited_once()
+    assert restored is original_registry
+    assert manager.registry is original_registry
+    assert manager.registry.to_dict() == replacement.to_dict()
+    assert notifications == [None]
+
+
+async def test_restore_storage_failure_leaves_live_registry_unchanged(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    original = _registry("Old socket", "OLD-01")
+    manager._adopt_staged_registry(original)
+    original_registry = manager.registry
+    baseline = manager.registry.to_dict()
+    backup = export_registry_backup(_registry("Replacement", "NEW-01"))
+    manager._store.async_save = AsyncMock(
+        side_effect=BindHomeStoreError("disk full")
+    )
+
+    notifications: list[None] = []
+    unsubscribe = async_dispatcher_connect(
+        hass,
+        SIGNAL_REGISTRY_CHANGED,
+        lambda: notifications.append(None),
+    )
+
+    try:
+        with pytest.raises(BindHomeStoreError, match="disk full"):
+            await async_restore_registry_backup(manager, backup)
+    finally:
+        unsubscribe()
+
+    manager._store.async_save.assert_awaited_once()
+    assert manager.registry is original_registry
+    assert manager.registry.to_dict() == baseline
+    assert notifications == []
+
+
+async def test_invalid_restore_never_attempts_persistence(hass: HomeAssistant) -> None:
+    manager = BindHomeManager(hass)
+    manager._store.async_save = AsyncMock()
+    baseline = manager.registry.to_dict()
+
+    with pytest.raises(BackupValidationError):
+        await async_restore_registry_backup(manager, {"format": "wrong"})
+
+    manager._store.async_save.assert_not_awaited()
+    assert manager.registry.to_dict() == baseline

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -151,9 +151,7 @@ async def test_restore_storage_failure_leaves_live_registry_unchanged(
     original_registry = manager.registry
     baseline = manager.registry.to_dict()
     backup = export_registry_backup(_registry("Replacement", "NEW-01"))
-    manager._store.async_save = AsyncMock(
-        side_effect=BindHomeStoreError("disk full")
-    )
+    manager._store.async_save = AsyncMock(side_effect=BindHomeStoreError("disk full"))
 
     notifications: list[None] = []
     unsubscribe = async_dispatcher_connect(

--- a/tests/test_backup_websocket.py
+++ b/tests/test_backup_websocket.py
@@ -1,0 +1,146 @@
+"""Tests for the BindHome backup WebSocket API."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.components.websocket_api.const import ERR_INVALID_FORMAT
+
+from custom_components.bindhome import backup_websocket
+from custom_components.bindhome.backup import (
+    BackupValidationError,
+    export_registry_backup,
+)
+from custom_components.bindhome.models import Asset
+from custom_components.bindhome.registry import BindHomeRegistry
+from custom_components.bindhome.store import BindHomeStoreError
+
+
+class FakeConnection:
+    """Capture WebSocket responses without a live Home Assistant server."""
+
+    def __init__(self) -> None:
+        self.user = SimpleNamespace(is_admin=True)
+        self.results: list[tuple[str, object]] = []
+        self.errors: list[tuple[str, str, str]] = []
+
+    def send_result(self, message_id: str, result: object = None) -> None:
+        self.results.append((message_id, result))
+
+    def send_error(self, message_id: str, code: str, message: str) -> None:
+        self.errors.append((message_id, code, message))
+
+
+class FakeManager:
+    """Minimal manager double used by backup handlers."""
+
+    def __init__(self) -> None:
+        self.registry = BindHomeRegistry()
+        self.registry.add_asset(
+            Asset.create(name="Socket", asset_type="socket", code="SOCK-01")
+        )
+
+
+def hass_for(manager: FakeManager) -> SimpleNamespace:
+    """Build the Home Assistant surface used by backup handlers."""
+    entry = SimpleNamespace(
+        state=backup_websocket.config_entries.ConfigEntryState.LOADED,
+        runtime_data=manager,
+    )
+    return SimpleNamespace(
+        config_entries=SimpleNamespace(async_entries=lambda domain: [entry]),
+    )
+
+
+def call(handler, hass, connection, msg):
+    """Call through the async handler decorator layers."""
+    return handler.__wrapped__.__wrapped__(hass, connection, msg)
+
+
+@pytest.mark.asyncio
+async def test_backup_export_returns_versioned_envelope() -> None:
+    manager = FakeManager()
+    connection = FakeConnection()
+
+    await call(
+        backup_websocket.ws_backup_export,
+        hass_for(manager),
+        connection,
+        {"id": "1"},
+    )
+
+    assert connection.errors == []
+    assert connection.results == [
+        ("1", {"backup": export_registry_backup(manager.registry)})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_backup_restore_returns_committed_registry(monkeypatch) -> None:
+    manager = FakeManager()
+    restored = BindHomeRegistry()
+    restored.add_asset(Asset.create(name="Restored", asset_type="socket", code="NEW-01"))
+    restore = AsyncMock(return_value=restored)
+    monkeypatch.setattr(backup_websocket, "async_restore_registry_backup", restore)
+    connection = FakeConnection()
+    backup = export_registry_backup(restored)
+
+    await call(
+        backup_websocket.ws_backup_restore,
+        hass_for(manager),
+        connection,
+        {"id": "2", "backup": backup},
+    )
+
+    restore.assert_awaited_once_with(manager, backup)
+    assert connection.errors == []
+    assert connection.results == [
+        ("2", {"restored": True, "registry": restored.to_dict()})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_backup_restore_translates_validation_error(monkeypatch) -> None:
+    manager = FakeManager()
+    restore = AsyncMock(side_effect=BackupValidationError("bad backup"))
+    monkeypatch.setattr(backup_websocket, "async_restore_registry_backup", restore)
+    connection = FakeConnection()
+
+    await call(
+        backup_websocket.ws_backup_restore,
+        hass_for(manager),
+        connection,
+        {"id": "3", "backup": {}},
+    )
+
+    assert connection.results == []
+    assert connection.errors == [("3", ERR_INVALID_FORMAT, "bad backup")]
+
+
+@pytest.mark.asyncio
+async def test_backup_restore_translates_storage_error(monkeypatch) -> None:
+    manager = FakeManager()
+    restore = AsyncMock(side_effect=BindHomeStoreError("disk full"))
+    monkeypatch.setattr(backup_websocket, "async_restore_registry_backup", restore)
+    connection = FakeConnection()
+
+    await call(
+        backup_websocket.ws_backup_restore,
+        hass_for(manager),
+        connection,
+        {"id": "4", "backup": {}},
+    )
+
+    assert connection.results == []
+    assert connection.errors == [("4", "storage_error", "disk full")]
+
+
+def test_registers_backup_commands_under_bindhome_namespace() -> None:
+    hass = SimpleNamespace(data={})
+
+    backup_websocket.async_register_backup_websocket_commands(hass)
+
+    assert set(hass.data["websocket_api"]) == {
+        backup_websocket.WS_BACKUP_EXPORT,
+        backup_websocket.WS_BACKUP_RESTORE,
+    }

--- a/tests/test_backup_websocket.py
+++ b/tests/test_backup_websocket.py
@@ -79,7 +79,13 @@ async def test_backup_export_returns_versioned_envelope() -> None:
 async def test_backup_restore_returns_committed_registry(monkeypatch) -> None:
     manager = FakeManager()
     restored = BindHomeRegistry()
-    restored.add_asset(Asset.create(name="Restored", asset_type="socket", code="NEW-01"))
+    restored.add_asset(
+        Asset.create(
+            name="Restored",
+            asset_type="socket",
+            code="NEW-01",
+        )
+    )
     restore = AsyncMock(return_value=restored)
     monkeypatch.setattr(backup_websocket, "async_restore_registry_backup", restore)
     connection = FakeConnection()


### PR DESCRIPTION
## P1 — Reliability & Release Foundation

This continues P1 by adding a stable, administrator-only backup/restore contract for the complete BindHome Registry.

### Backup format

Exports use a deterministic versioned envelope:

- `format: bindhome.registry`
- `format_version: 1`
- `registry`: the complete serialized BindHome Registry, including its independent `schema_version`

No timestamps or environment-specific metadata are included, so identical Registry state produces identical backup payloads.

### Restore contract

Restore is a full Registry replacement, not a merge. BindHome:

1. validates the backup envelope and backup format version;
2. deserializes and validates the complete Registry into isolated staged state;
3. acquires the existing manager mutation lock;
4. persists staged state through the fail-fast atomic Store;
5. only after persistence succeeds, adopts staged contents into the existing live Registry object;
6. emits `SIGNAL_REGISTRY_CHANGED` only after commit.

Malformed backups, unsupported backup versions, unsupported Registry schema versions, and invalid Registry contents fail before persistence.

Storage failure leaves live RAM unchanged and emits no Registry-changed signal.

### API

Adds administrator-only WebSocket commands:

- `bindhome/backup/export`
- `bindhome/backup/restore`

This deliberately avoids direct manipulation of Home Assistant `.storage` files.

### Tests

Adds coverage for:

- deterministic versioned export;
- exact backup round trip;
- malformed envelope rejection;
- future backup format rejection;
- future Registry schema rejection;
- persistence-before-adoption ordering;
- live Registry identity preservation;
- storage failure atomicity;
- invalid restore making no persistence attempt;
- WebSocket success/error contracts and registration.

### Non-goals

No UX, no file-download UI, no Registry merge semantics, no new domain entities, and no direct `.storage` access.