### PR TITLE
ci: automate stable GitHub release publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,209 @@
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "custom_components/bindhome/manifest.json"
+      - "pyproject.toml"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      - "CHANGELOG.md"
+      - ".github/workflows/release.yml"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: bindhome-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Verify release metadata
+        id: metadata
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+          import tomllib
+
+          root = pathlib.Path('.')
+          pyproject = tomllib.loads((root / 'pyproject.toml').read_text())
+          manifest = json.loads(
+              (root / 'custom_components/bindhome/manifest.json').read_text()
+          )
+          package = json.loads((root / 'frontend/package.json').read_text())
+          package_lock = json.loads((root / 'frontend/package-lock.json').read_text())
+
+          versions = {
+              'pyproject.toml': pyproject['project']['version'],
+              'manifest.json': manifest['version'],
+              'frontend/package.json': package['version'],
+              'frontend/package-lock.json': package_lock['version'],
+              'frontend/package-lock.json root package': package_lock['packages']['']['version'],
+          }
+
+          if len(set(versions.values())) != 1:
+              raise SystemExit(f'Version metadata mismatch: {versions}')
+
+          version = next(iter(versions.values()))
+          if not re.fullmatch(r'\d+\.\d+\.\d+', version):
+              raise SystemExit(f'Version is not SemVer-compatible: {version}')
+
+          changelog = (root / 'CHANGELOG.md').read_text()
+          if not re.search(rf'^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}$', changelog, re.MULTILINE):
+              raise SystemExit(f'CHANGELOG.md has no finalized section for {version}')
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as output:
+              output.write(f'version={version}\n')
+              output.write(f'tag=v{version}\n')
+
+          print(f'Release metadata is coherent for BindHome {version}')
+          PY
+
+      - name: Check whether release already exists
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.metadata.outputs.tag }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; nothing to publish."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for required release gates
+        if: steps.existing.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 60); do
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/$GITHUB_REPOSITORY/commits/$TARGET_SHA/check-runs?per_page=100" \
+              > /tmp/check-runs.json
+
+            if python - <<'PY'
+          import json
+          import sys
+
+          required = {
+              'Release Metadata',
+              'Pytest',
+              'Ruff Lint & Format',
+              'Hassfest',
+              'Frontend',
+              'HACS Validation',
+              'HA 2026.8.0',
+              'HA 2026.9.0',
+          }
+
+          data = json.load(open('/tmp/check-runs.json'))
+          runs = {run['name']: run for run in data.get('check_runs', [])}
+          missing = sorted(required - runs.keys())
+
+          if missing:
+              print('Waiting for checks to appear:', ', '.join(missing))
+              sys.exit(2)
+
+          failed = []
+          pending = []
+          for name in sorted(required):
+              run = runs[name]
+              if run.get('status') != 'completed':
+                  pending.append(name)
+              elif run.get('conclusion') != 'success':
+                  failed.append(f"{name}={run.get('conclusion')}")
+
+          if failed:
+              print('Release gate failed:', ', '.join(failed))
+              sys.exit(1)
+
+          if pending:
+              print('Waiting for checks:', ', '.join(pending))
+              sys.exit(2)
+
+          print('All required release gates passed.')
+          PY
+            then
+              break
+            else
+              status=$?
+              if [ "$status" -eq 1 ]; then
+                exit 1
+              fi
+            fi
+
+            if [ "$attempt" -eq 60 ]; then
+              echo "Timed out waiting for required release gates."
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+      - name: Extract release notes from changelog
+        if: steps.existing.outputs.exists != 'true'
+        env:
+          VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import re
+
+          changelog = pathlib.Path('CHANGELOG.md').read_text()
+          version = os.environ['VERSION']
+          marker = re.search(
+              rf'^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}$',
+              changelog,
+              re.MULTILINE,
+          )
+          if marker is None:
+              raise SystemExit(f'No changelog section found for {version}')
+
+          section = changelog[marker.end():].lstrip('\n')
+          next_version = re.search(r'^## \[', section, re.MULTILINE)
+          if next_version is not None:
+              section = section[:next_version.start()]
+
+          link_separator = section.find('\n---\n')
+          if link_separator != -1:
+              section = section[:link_separator]
+
+          notes = section.strip() + '\n'
+          pathlib.Path('/tmp/release-notes.md').write_text(notes)
+          print(notes)
+          PY
+
+      - name: Publish stable GitHub Release
+        if: steps.existing.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.metadata.outputs.tag }}
+          VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "BindHome $VERSION" \
+            --notes-file /tmp/release-notes.md \
+            --latest

--- a/docs/release.md
+++ b/docs/release.md
@@ -36,7 +36,7 @@ At release time:
 3. leave a fresh `Unreleased` section at the top;
 4. add or update comparison/release links at the bottom of the file;
 5. ensure migrations, minimum Home Assistant changes, deprecations and breaking changes are explicit;
-6. use the finalized changelog section as the basis for the GitHub Release notes.
+6. use the finalized changelog section as the GitHub Release notes.
 
 Generated bundles, formatting-only changes and internal refactors do not need changelog entries unless they materially affect users, compatibility, reliability or release operations.
 
@@ -62,25 +62,39 @@ custom_components/bindhome/panel/static/bindhome-panel.js
 
 The release gate rebuilds this bundle and verifies that the committed artifact is current. Development source and tests must not be moved back into the HACS runtime tree.
 
+## Automated publication
+
+`.github/workflows/release.yml` is the publication boundary for stable BindHome releases.
+
+When a merge to `main` changes release metadata, the changelog, or the release workflow itself, the publisher:
+
+1. verifies that all version metadata agrees and that `CHANGELOG.md` contains a finalized section for that version;
+2. exits without changing anything if the corresponding GitHub Release already exists;
+3. waits for the exact merged `main` commit to pass `Release Metadata`, `Pytest`, `Ruff Lint & Format`, `Hassfest`, `Frontend`, `HACS Validation`, `HA 2026.8.0`, and `HA 2026.9.0`;
+4. fails closed if any required gate fails or the gate does not complete within the bounded wait;
+5. extracts the release notes from the matching `CHANGELOG.md` section;
+6. creates the immutable `v<version>` tag and stable GitHub Release on that exact commit.
+
+Publication therefore cannot race ahead of the protected release gate. Re-running the workflow is idempotent for an already published version.
+
 ## Release checklist
 
 1. Start from an up-to-date `main` and a dedicated release branch.
 2. Set the intended BindHome version in all release metadata.
 3. Review `CHANGELOG.md`: ensure every notable merged change since the previous release is present, move `Unreleased` into the release version/date, and leave a fresh `Unreleased` section.
-4. Confirm the Home Assistant compatibility matrix is green.
-5. Confirm Validate, Hassfest, frontend and HACS validation are green.
+4. Confirm the Home Assistant compatibility matrix is green on the release PR.
+5. Confirm Validate, Hassfest, frontend and HACS validation are green on the release PR.
 6. Confirm the README, changelog and release notes describe the supported Home Assistant range and any migrations.
 7. For a public release, confirm the repository itself satisfies HACS publication metadata requirements.
 8. Confirm `custom_components/bindhome` contains runtime files only and no local development workspace/tool artifacts.
 9. Merge the release PR into `main`.
-10. Confirm all workflows are green on the exact merged `main` commit.
-11. Create tag `v<version>` on that exact commit.
-12. Create the GitHub Release from that tag; do not move or reuse an existing release tag.
-13. Install or upgrade the release through HACS in a development Home Assistant instance.
-14. Restart Home Assistant and verify BindHome loads, the Registry is intact, logical entities reconcile, and the panel opens.
-15. Keep the previous release available for controlled downgrade when one exists.
+10. Let the publication workflow wait for all required checks on the exact merged `main` commit and create `v<version>` plus the GitHub Release.
+11. Verify that the published release targets that exact green commit and that its notes match the finalized changelog section.
+12. Install or upgrade the release through HACS in a development Home Assistant instance.
+13. Restart Home Assistant and verify BindHome loads, the Registry is intact, logical entities reconcile, and the panel opens.
+14. Keep the previous release available for controlled downgrade when one exists.
 
-For the first public release, the repository must be public before the final HACS publication validation. `v1.0.0` is created only after the release-preparation PR is merged and the exact resulting `main` commit is green.
+For the first public release, the repository must be public before the final HACS publication validation. `v1.0.0` is published only after the release-preparation changes are on protected `main` and the exact resulting commit passes every required gate.
 
 ## Upgrade
 


### PR DESCRIPTION
## Release publication automation

This PR adds the permanent release publisher needed to publish `v1.0.0` without a manual GitHub release step and to keep future releases reproducible.

### Behavior

On a relevant merge to `main`, the publisher:

- verifies all BindHome version metadata is identical and SemVer-compatible;
- requires a finalized `CHANGELOG.md` section for that version;
- exits idempotently when the release already exists;
- waits for the exact merged SHA to pass all eight protected release gates (`Release Metadata`, `Pytest`, `Ruff Lint & Format`, `Hassfest`, `Frontend`, `HACS Validation`, `HA 2026.8.0`, `HA 2026.9.0`);
- fails closed on a failed gate or bounded timeout;
- extracts GitHub Release notes from the matching changelog section;
- creates immutable `v<version>` and a stable GitHub Release on that exact green `main` commit.

### Documentation

`docs/release.md` now describes automated publication and the resulting release checklist.

Once this PR is merged and the `main` gates are green, its push-triggered workflow will publish **BindHome 1.0.0** automatically.