### PR TITLE
fix: classify BindHome as a hub integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,24 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 
 ## [Unreleased]
 
-No changes yet beyond `1.1.0`.
+No changes yet beyond `1.1.1`.
+
+---
+
+## [1.1.1] - 2026-09-05
+
+Patch release correcting BindHome's Home Assistant integration classification.
+
+**Minimum Home Assistant:** `2026.8.0`
+
+### Fixed
+
+- BindHome is now declared as a `hub` integration instead of a `helper`. It therefore belongs under **Settings → Devices & services → Integrations**, rather than the Helpers screen. The previous helper classification caused Home Assistant to offer a helper-edit/options flow that BindHome does not implement, producing `Invalid handler specified` when the BindHome row was opened.
+- Existing BindHome config entries, Registry storage, Assets, Relations, Bindings and Representations are unchanged by this metadata correction.
+
+### Distribution
+
+- Version promoted to `1.1.1` across Python, Home Assistant and frontend package metadata.
 
 ---
 
@@ -133,6 +150,7 @@ First public BindHome release.
 
 ---
 
-[Unreleased]: https://github.com/alessbarb/bindhome/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/alessbarb/bindhome/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/alessbarb/bindhome/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/alessbarb/bindhome/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/alessbarb/bindhome/releases/tag/v1.0.0

--- a/custom_components/bindhome/manifest.json
+++ b/custom_components/bindhome/manifest.json
@@ -12,10 +12,10 @@
     "http"
   ],
   "documentation": "https://github.com/alessbarb/bindhome",
-  "integration_type": "helper",
+  "integration_type": "hub",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/alessbarb/bindhome/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bindhome-panel",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bindhome-panel",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "lit": "^3.3.3"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bindhome-panel",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bindhome"
-version = "1.1.0"
+version = "1.1.1"
 description = "Stable home infrastructure bound to replaceable Home Assistant hardware"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/test_manifest_metadata.py
+++ b/tests/test_manifest_metadata.py
@@ -1,0 +1,16 @@
+"""Tests for BindHome manifest metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+MANIFEST_PATH = Path("custom_components/bindhome/manifest.json")
+
+
+def test_bindhome_is_registered_as_hub() -> None:
+    """BindHome must not be exposed through Home Assistant's Helpers UI."""
+    manifest = json.loads(MANIFEST_PATH.read_text())
+
+    assert manifest["integration_type"] == "hub"

--- a/tests/test_manifest_metadata.py
+++ b/tests/test_manifest_metadata.py
@@ -1,10 +1,10 @@
 """Tests for BindHome manifest metadata."""
 
 import json
-from pathlib import Path
+import pathlib
 
 
-MANIFEST_PATH = Path("custom_components/bindhome/manifest.json")
+MANIFEST_PATH = pathlib.Path("custom_components/bindhome/manifest.json")
 
 
 def test_bindhome_is_registered_as_hub() -> None:

--- a/tests/test_manifest_metadata.py
+++ b/tests/test_manifest_metadata.py
@@ -1,14 +1,14 @@
 """Tests for BindHome manifest metadata."""
 
 import json
-import pathlib
 
 
-MANIFEST_PATH = pathlib.Path("custom_components/bindhome/manifest.json")
+MANIFEST_PATH = "custom_components/bindhome/manifest.json"
 
 
 def test_bindhome_is_registered_as_hub() -> None:
     """BindHome must not be exposed through Home Assistant's Helpers UI."""
-    manifest = json.loads(MANIFEST_PATH.read_text())
+    with open(MANIFEST_PATH, encoding="utf-8") as manifest_file:
+        manifest = json.load(manifest_file)
 
     assert manifest["integration_type"] == "hub"

--- a/tests/test_manifest_metadata.py
+++ b/tests/test_manifest_metadata.py
@@ -2,7 +2,6 @@
 
 import json
 
-
 MANIFEST_PATH = "custom_components/bindhome/manifest.json"
 
 

--- a/tests/test_manifest_metadata.py
+++ b/tests/test_manifest_metadata.py
@@ -1,7 +1,5 @@
 """Tests for BindHome manifest metadata."""
 
-from __future__ import annotations
-
 import json
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

Fixes the Home Assistant `Invalid handler specified` error seen when opening BindHome from **Settings → Devices & services → Helpers**.

BindHome was incorrectly declared with `integration_type: helper`. Home Assistant reserves that classification for helper entities and treats rows on the Helpers screen as editable helper config entries. Opening the BindHome row therefore attempted to create an options flow, but BindHome intentionally has no options flow because it has no ordinary integration settings to edit.

This PR:

- changes BindHome from `integration_type: helper` to `integration_type: hub`;
- keeps the one-click config flow unchanged;
- preserves the existing config entry and Registry data model with no migration;
- adds a regression test pinning the manifest classification;
- prepares patch release `1.1.1` across Python, Home Assistant, frontend package and lockfile metadata;
- documents the fix in the changelog.

## User impact

After installing 1.1.1 and restarting Home Assistant, BindHome should be managed as a normal integration under **Settings → Devices & services → Integrations**, not under Helpers. Existing Assets, Relations, Bindings, Representations and persisted Registry data are unaffected.

## Compatibility

Minimum supported Home Assistant remains `2026.8.0`.
