### PR TITLE
docs: clarify Binding identity and record product positioning

### DIFF
--- a/docs/adr/0001-infrastructure-model-is-the-product-core.md
+++ b/docs/adr/0001-infrastructure-model-is-the-product-core.md
@@ -1,0 +1,81 @@
+# ADR 0001: The infrastructure model is the product core
+
+- **Status:** Accepted
+- **Date:** 2026-09-05
+
+## Context
+
+BindHome has two visible value surfaces:
+
+1. documenting and querying a stable physical model of the home; and
+2. exposing selected Assets back into Home Assistant through stable logical Representations.
+
+Both are useful, but treating them as equal product centers makes prioritization ambiguous. It becomes unclear whether to spend the next unit of effort on inventory/import/topology/export workflows or on implementing more Home Assistant entity platforms.
+
+The project also has a deliberate ownership boundary: Home Assistant remains authoritative for Devices, Entities, Areas, Floors, runtime state and hardware behaviour, while BindHome owns the additional physical infrastructure model.
+
+## Decision
+
+**The stable physical infrastructure model is BindHome's product core.**
+
+Assets, Capabilities, Relations and Bindings form the durable model. Inventory, topology, diagnostics, replacement workflows, reporting and resolution APIs are ways to create, maintain and exploit that model.
+
+Representations are an important exploitation surface of the model, but they are not the product by themselves. BindHome should implement Representations where they provide clear user value without attempting to recreate Home Assistant's entity platform ecosystem.
+
+In practical terms:
+
+- a passive Asset with no smart hardware remains a first-class BindHome object;
+- a useful BindHome installation does not require every Asset to have a Representation;
+- Representation quality must be high where offered, but platform breadth is secondary to model integrity and useful workflows;
+- import, inventory, topology, recovery, migration, diagnostics, resolver APIs and export are core product work, not supporting extras;
+- Home Assistant remains the runtime and automation engine rather than something BindHome duplicates.
+
+## Consequences
+
+### Roadmap ordering
+
+When priorities conflict, prefer work that strengthens the durable infrastructure model or reduces the cost of creating/maintaining it before broad platform expansion.
+
+Examples:
+
+- recovery and schema migration before schema expansion;
+- stable Binding identity before large import/rebinding workflows;
+- reliable inventory/topology/export workflows before implementing many new Representation platforms;
+- correct event-driven/proxy behavior for existing Representations before adding more platforms.
+
+### Representation scope
+
+New Representation platforms should be added deliberately and platform by platform. They must reuse the stable Asset/Binding model and must not introduce a parallel device/entity abstraction inside BindHome.
+
+### Product evaluation
+
+A feature should be evaluated by whether it improves at least one of these outcomes:
+
+- makes the physical model easier to create;
+- makes it safer/easier to maintain over hardware changes;
+- makes the model more useful for diagnostics, automation, topology or documentation;
+- exposes a stable Home Assistant interface without weakening the ownership boundary.
+
+## Rejected alternatives
+
+### BindHome as an inventory-only application
+
+Rejected because stable runtime abstraction and hardware replacement are valuable consequences of the model and are central to the original motivation.
+
+### BindHome as primarily a logical-entity proxy framework
+
+Rejected because it would make passive infrastructure, topology, inventory and documentation secondary and would push BindHome toward reimplementing Home Assistant entity semantics platform by platform.
+
+### Maintain both as equal product centers
+
+Rejected because it provides no rule for prioritization and encourages simultaneous expansion in incompatible directions.
+
+## Non-goals reinforced by this ADR
+
+This decision does not change the existing non-goals:
+
+- no replacement of Home Assistant Devices, Entities, Areas or Floors;
+- no automatic physical-topology inference;
+- no BindHome automation engine;
+- no complete infrastructure ontology/CAD system;
+- no generic entity platform that guesses semantics from Home Assistant domain names.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,8 @@ Stable physical Asset
 
 The core rule is simple: replacing smart hardware should normally change a Binding, not the identity of the physical thing being modelled.
 
+The product positioning behind this architecture is recorded in [ADR 0001: the infrastructure model is the product core](adr/0001-product-positioning.md).
+
 ## Ownership boundary
 
 Home Assistant remains authoritative for:
@@ -78,7 +80,7 @@ The Home Assistant entity is replaceable. Setting a new Binding for the same fun
 
 Binding targets may also be logical entities produced by BindHome Representations. BindHome-to-BindHome composition is allowed only when the resulting functional dependency graph remains acyclic. Cycle validation operates at `(asset_id, capability, role)` granularity.
 
-The Home Assistant Entity Registry remains authoritative for entity identity, including after entity-id renames.
+Home Assistant's Entity Registry is authoritative for registered entity identity, but BindHome 1.1.x currently persists the mutable `entity_id` string in hardware Bindings. Renaming a bound entity in Home Assistant can therefore make that Binding stale until it is rebound. Stable Entity Registry target identity is planned in issue #31.
 
 ### Relation
 
@@ -94,7 +96,7 @@ A Representation is BindHome's explicit decision to expose an Asset back into Ho
 
 Capability and Representation are separate concepts. An Asset may have `on_off` without being represented as a Home Assistant Light.
 
-BindHome 1.0 supports zero or one Representation per Asset. The implemented logical platform is currently `light`, which requires the BindHome `on_off` Capability.
+BindHome 1.x supports zero or one Representation per Asset. The implemented logical platform is currently `light`, which requires the BindHome `on_off` Capability.
 
 Representation requirements describe BindHome's own implementation contract; they are not a compatibility catalogue for Home Assistant domains.
 
@@ -272,7 +274,7 @@ Language changes update presentation without resetting mounted workflow state.
 
 ## Compatibility and release boundary
 
-BindHome 1.0.0 supports Home Assistant `2026.8.0` and newer compatible releases. CI tests the complete Python suite against the minimum supported Home Assistant version and the current stable release used for the release baseline.
+BindHome 1.x supports Home Assistant `2026.8.0` and newer compatible releases. CI tests the complete Python suite against the minimum supported Home Assistant version and the current stable release used for the release baseline.
 
 Release metadata is synchronized across Python, Home Assistant manifest and frontend package metadata. HACS, Hassfest, Python, frontend and compatibility validation form the release gate.
 
@@ -280,7 +282,7 @@ See [Release process](release.md).
 
 ## Architectural non-goals
 
-BindHome 1.0 does not attempt to:
+BindHome 1.x does not attempt to:
 
 - replace Home Assistant Devices, Entities, Areas or Floors;
 - infer physical topology automatically;


### PR DESCRIPTION
## Summary

Small documentation/governance correction after the 1.1.1 audit.

- Corrects `docs/architecture.md` so it no longer claims current hardware Bindings survive Home Assistant `entity_id` renames.
- Records the current limitation explicitly until #31 lands.
- Adds ADR 0001: the stable physical infrastructure model is BindHome's product core; Representations are an exploitation surface of that model, not the sole product.
- Normalizes version wording in architecture docs to `1.x` where the contract is not tied to 1.0 specifically.

## Why now

The architecture document is normative enough that it should describe current behavior, not the intended future behavior. The ADR also gives the backlog a stable rule for choosing between inventory/topology/model work and Representation platform expansion.

No runtime code or Registry data changes.