### PR TITLE
refactor: expose a public Registry transaction API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,15 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 
 ## [Unreleased]
 
-No changes yet beyond `1.1.1`.
+### Changed
+
+- Registry multi-step mutations now have a supported public `BindHomeManager.transaction()` boundary. Backup restore and dependency-aware Asset deletion use that API instead of reaching into private manager locking/staging/commit internals. ([#62](https://github.com/alessbarb/bindhome/pull/62))
+
+### Reliability
+
+- Same-task nested manager mutations inside an open Registry transaction now fail immediately with an explicit transaction error instead of being able to deadlock on a non-reentrant `asyncio.Lock`; concurrent mutations from different tasks continue to serialize normally. ([#62](https://github.com/alessbarb/bindhome/pull/62))
+- Staged Registry state is revalidated before persistence, and the manager-independent store write path now validates canonical state before touching Home Assistant storage, giving future startup migrations a documented validate-before-write persistence primitive. ([#62](https://github.com/alessbarb/bindhome/pull/62))
+- Live Registry adoption derives its persisted collection set from the Registry serialization contract instead of maintaining a separate hand-written list, so future persisted collections cannot be silently omitted; new persisted fields without collection semantics fail closed until explicitly handled. ([#62](https://github.com/alessbarb/bindhome/pull/62))
 
 ---
 

--- a/custom_components/bindhome/backup.py
+++ b/custom_components/bindhome/backup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .registry import BindHomeRegistry, RegistryValidationError
+from .registry_state import replace_registry_contents
 
 if TYPE_CHECKING:
     from .manager import BindHomeManager
@@ -61,9 +62,9 @@ async def async_restore_registry_backup(
     data: object,
 ) -> BindHomeRegistry:
     """Validate and atomically replace the live Registry from a backup."""
-    staged = parse_registry_backup(data)
+    replacement = parse_registry_backup(data)
 
-    async with manager._mutation_lock:
-        await manager._async_commit_staged_registry(staged)
+    async with manager.transaction() as staged:
+        replace_registry_contents(staged, replacement)
 
     return manager.registry

--- a/custom_components/bindhome/deletion.py
+++ b/custom_components/bindhome/deletion.py
@@ -102,8 +102,7 @@ async def async_delete_asset_with_dependencies(
     asset_id: str,
 ) -> AssetDeleteImpact:
     """Delete an Asset and its BindHome-owned dependencies as one transaction."""
-    async with manager._mutation_lock:
-        staged = manager._stage_registry()
+    async with manager.transaction() as staged:
         impact = build_asset_delete_impact(manager, asset_id, registry=staged)
 
         for relation in impact.relations:
@@ -123,5 +122,5 @@ async def async_delete_asset_with_dependencies(
         # BindHome reference type is added later and is not cleaned above, the
         # transaction fails closed rather than leaving an orphan.
         staged.delete_asset(asset_id)
-        await manager._async_commit_staged_registry(staged)
-        return impact
+
+    return impact

--- a/custom_components/bindhome/manager.py
+++ b/custom_components/bindhome/manager.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
 from homeassistant.core import HomeAssistant
@@ -21,6 +22,7 @@ from .registry import (
     RegistryError,
     RegistryValidationError,
 )
+from .registry_state import replace_registry_contents
 from .representation import (
     binding_key,
     representation_asset_for_entity,
@@ -28,6 +30,7 @@ from .representation import (
 )
 from .resolver import BindingResolver, HomeAssistantEntityProbe
 from .store import BindHomeStore
+from .transaction import BindHomeMutationLock
 from .validation import validate_entity
 
 
@@ -95,13 +98,28 @@ class BindHomeManager:
         self.hass = hass
         self.registry = BindHomeRegistry()
         self._store = BindHomeStore(hass)
-        self._mutation_lock = asyncio.Lock()
+        self._mutation_lock = BindHomeMutationLock()
         self._probe = HomeAssistantEntityProbe(hass)
 
     @property
     def resolver(self) -> BindingResolver:
         """Return a resolver bound to the current registry and Home Assistant."""
         return BindingResolver(self.registry, self._probe)
+
+    @asynccontextmanager
+    async def transaction(self) -> AsyncIterator[BindHomeRegistry]:
+        """Yield an isolated Registry and commit it once on successful exit.
+
+        Concurrent callers serialize through the mutation lock. Re-entering the
+        manager from the same task while a transaction is open fails fast rather
+        than deadlocking on ``asyncio.Lock`` semantics. Transaction callers must
+        therefore perform multi-step changes directly against the staged
+        Registry yielded here.
+        """
+        async with self._mutation_lock:
+            staged = self._stage_registry()
+            yield staged
+            await self._async_commit_staged_registry(staged)
 
     def _stage_registry(self) -> BindHomeRegistry:
         """Return an isolated validated copy of the live registry."""
@@ -111,29 +129,20 @@ class BindHomeManager:
         self,
         staged: BindHomeRegistry,
     ) -> None:
-        """Persist staged state, then atomically publish it to runtime consumers."""
-        await self._store.async_save(staged)
-        self._adopt_staged_registry(staged)
+        """Persist validated staged state, then publish it to runtime consumers."""
+        canonical = BindHomeRegistry.from_dict(staged.to_dict())
+        await self._store.async_save(canonical)
+        self._adopt_staged_registry(canonical)
         async_dispatcher_send(self.hass, SIGNAL_REGISTRY_CHANGED)
 
     def _adopt_staged_registry(self, staged: BindHomeRegistry) -> None:
         """Commit staged state while preserving the live registry identity.
 
         Long-lived runtime consumers may retain references to the current
-        BindHomeRegistry, so commits replace its contents rather than replacing
-        the registry object itself.
+        BindHomeRegistry, so commits replace its persisted collections rather
+        than replacing the registry object itself.
         """
-        self.registry.assets.clear()
-        self.registry.assets.update(staged.assets)
-
-        self.registry.relations.clear()
-        self.registry.relations.update(staged.relations)
-
-        self.registry.bindings.clear()
-        self.registry.bindings.update(staged.bindings)
-
-        self.registry.representations.clear()
-        self.registry.representations.update(staged.representations)
+        replace_registry_contents(self.registry, staged)
 
     async def async_load(self) -> None:
         """Load persisted registry state."""

--- a/custom_components/bindhome/registry_state.py
+++ b/custom_components/bindhome/registry_state.py
@@ -1,0 +1,64 @@
+"""Helpers for replacing persisted BindHome Registry contents safely."""
+
+from __future__ import annotations
+
+from .registry import BindHomeRegistry, RegistryValidationError
+
+_SCHEMA_KEYS = {"schema_version"}
+
+
+def _persisted_collection_names(registry: BindHomeRegistry) -> tuple[str, ...]:
+    """Return persisted collection names and verify their in-memory shape.
+
+    The list is derived from ``to_dict()`` rather than duplicated manually so a
+    future persisted collection cannot be silently omitted from live adoption.
+    Persisted top-level scalar fields require an explicit adoption design and
+    therefore fail closed here instead of being ignored.
+    """
+    names = sorted(set(registry.to_dict()) - _SCHEMA_KEYS)
+    invalid = [
+        name
+        for name in names
+        if not isinstance(getattr(registry, name, None), dict)
+    ]
+    if invalid:
+        raise RegistryValidationError(
+            "Persisted Registry fields require explicit adoption semantics: "
+            + ", ".join(invalid)
+        )
+    return tuple(names)
+
+
+def replace_registry_contents(
+    target: BindHomeRegistry,
+    source: BindHomeRegistry,
+) -> None:
+    """Replace persisted collections while preserving ``target`` identity."""
+    if target is source:
+        return
+
+    target_names = _persisted_collection_names(target)
+    source_names = _persisted_collection_names(source)
+    if target_names != source_names:
+        raise RegistryValidationError(
+            "Live and staged Registry persisted collections do not match"
+        )
+
+    collections: list[tuple[dict[object, object], dict[object, object]]] = []
+    for name in target_names:
+        target_collection = getattr(target, name)
+        source_collection = getattr(source, name)
+        collections.append((target_collection, source_collection))
+
+    # Validate every collection before mutating any live state.
+    for target_collection, source_collection in collections:
+        if not isinstance(target_collection, dict) or not isinstance(
+            source_collection, dict
+        ):
+            raise RegistryValidationError(
+                "Persisted Registry collection adoption requires dictionaries"
+            )
+
+    for target_collection, source_collection in collections:
+        target_collection.clear()
+        target_collection.update(source_collection)

--- a/custom_components/bindhome/registry_state.py
+++ b/custom_components/bindhome/registry_state.py
@@ -17,9 +17,7 @@ def _persisted_collection_names(registry: BindHomeRegistry) -> tuple[str, ...]:
     """
     names = sorted(set(registry.to_dict()) - _SCHEMA_KEYS)
     invalid = [
-        name
-        for name in names
-        if not isinstance(getattr(registry, name, None), dict)
+        name for name in names if not isinstance(getattr(registry, name, None), dict)
     ]
     if invalid:
         raise RegistryValidationError(

--- a/custom_components/bindhome/store.py
+++ b/custom_components/bindhome/store.py
@@ -97,13 +97,22 @@ class BindHomeStore:
                 f"Persisted BindHome registry is invalid: {err}"
             ) from err
 
-        # Persist the already-supported legacy in-memory migration once so
-        # future starts load the canonical explicit Representation form.
+        # Startup canonicalization deliberately uses the same manager-independent
+        # validate-before-write persistence primitive as runtime commits. Future
+        # schema migrations can therefore persist a canonical payload without
+        # inventing a third write path before a live manager exists.
         if "schema_version" not in data or "representations" not in data:
             await self.async_save(registry)
 
         return registry
 
     async def async_save(self, registry: BindHomeRegistry) -> None:
-        """Persist the registry immediately or raise on storage failure."""
-        await self._store.async_save(registry.to_dict())
+        """Validate canonical Registry state, then persist it atomically.
+
+        This method is safe to use both for runtime commits and during startup,
+        when no live manager, mutation lock or Registry-changed signal exists.
+        Validation/serialization must complete before Home Assistant storage is
+        touched.
+        """
+        canonical = BindHomeRegistry.from_dict(registry.to_dict())
+        await self._store.async_save(canonical.to_dict())

--- a/custom_components/bindhome/transaction.py
+++ b/custom_components/bindhome/transaction.py
@@ -1,0 +1,50 @@
+"""Transaction primitives for BindHome Registry mutations."""
+
+from __future__ import annotations
+
+import asyncio
+from types import TracebackType
+from typing import Any
+
+
+class BindHomeTransactionError(RuntimeError):
+    """Raised when the public Registry transaction contract is violated."""
+
+
+class BindHomeMutationLock:
+    """Serialize mutations and fail fast on same-task re-entry.
+
+    ``asyncio.Lock`` is intentionally not re-entrant. A normal nested acquire by
+    the same task would therefore deadlock silently. BindHome turns that failure
+    mode into an explicit error while preserving ordinary waiting semantics for
+    concurrent tasks.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._owner: asyncio.Task[Any] | None = None
+
+    async def __aenter__(self) -> BindHomeMutationLock:
+        task = asyncio.current_task()
+        if task is not None and task is self._owner:
+            raise BindHomeTransactionError(
+                "Cannot start a BindHome mutation inside an active Registry "
+                "transaction; mutate the staged Registry directly instead"
+            )
+
+        await self._lock.acquire()
+        self._owner = task
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self._owner = None
+        self._lock.release()
+
+    def locked(self) -> bool:
+        """Return whether a mutation currently owns the underlying lock."""
+        return self._lock.locked()

--- a/tests/test_public_transaction.py
+++ b/tests/test_public_transaction.py
@@ -12,7 +12,10 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from custom_components.bindhome.const import SIGNAL_REGISTRY_CHANGED
 from custom_components.bindhome.manager import BindHomeManager
 from custom_components.bindhome.models import Asset, Relation
-from custom_components.bindhome.registry import BindHomeRegistry, RegistryValidationError
+from custom_components.bindhome.registry import (
+    BindHomeRegistry,
+    RegistryValidationError,
+)
 from custom_components.bindhome.registry_state import replace_registry_contents
 from custom_components.bindhome.store import BindHomeStore
 from custom_components.bindhome.transaction import BindHomeTransactionError
@@ -101,7 +104,10 @@ async def test_public_mutation_inside_transaction_fails_fast(
             )
         )
 
-        with pytest.raises(BindHomeTransactionError, match="active Registry transaction"):
+        with pytest.raises(
+            BindHomeTransactionError,
+            match="active Registry transaction",
+        ):
             async with asyncio.timeout(0.1):
                 await manager.async_create_asset(
                     name="Nested socket",

--- a/tests/test_public_transaction.py
+++ b/tests/test_public_transaction.py
@@ -1,0 +1,247 @@
+"""Tests for the public BindHome Registry transaction contract."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from custom_components.bindhome.const import SIGNAL_REGISTRY_CHANGED
+from custom_components.bindhome.manager import BindHomeManager
+from custom_components.bindhome.models import Asset, Relation
+from custom_components.bindhome.registry import BindHomeRegistry, RegistryValidationError
+from custom_components.bindhome.registry_state import replace_registry_contents
+from custom_components.bindhome.store import BindHomeStore
+from custom_components.bindhome.transaction import BindHomeTransactionError
+
+
+async def test_public_transaction_commits_once_and_signals_once(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    original_registry = manager.registry
+
+    real_save = manager._store.async_save
+    manager._store.async_save = AsyncMock(wraps=real_save)
+    notifications: list[None] = []
+    unsubscribe = async_dispatcher_connect(
+        hass,
+        SIGNAL_REGISTRY_CHANGED,
+        lambda: notifications.append(None),
+    )
+
+    try:
+        async with manager.transaction() as staged:
+            asset = staged.add_asset(
+                Asset.create(
+                    name="Socket",
+                    asset_type="socket",
+                    code="SOCK-01",
+                    area_id=None,
+                    capabilities=[],
+                )
+            )
+            assert manager.registry is original_registry
+            assert asset.id not in manager.registry.assets
+
+        await hass.async_block_till_done()
+
+        assert manager._store.async_save.await_count == 1
+        assert manager.registry is original_registry
+        assert manager.registry.get_asset(asset.id) == asset
+        assert notifications == [None]
+    finally:
+        unsubscribe()
+
+
+async def test_public_transaction_exception_does_not_persist_or_publish(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    baseline = manager.registry.to_dict()
+    manager._store.async_save = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="abort staged mutation"):
+        async with manager.transaction() as staged:
+            staged.add_asset(
+                Asset.create(
+                    name="Socket",
+                    asset_type="socket",
+                    code="SOCK-01",
+                    area_id=None,
+                    capabilities=[],
+                )
+            )
+            raise RuntimeError("abort staged mutation")
+
+    manager._store.async_save.assert_not_awaited()
+    assert manager.registry.to_dict() == baseline
+
+
+async def test_public_mutation_inside_transaction_fails_fast(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    manager._store.async_save = AsyncMock()
+
+    async with manager.transaction() as staged:
+        staged.add_asset(
+            Asset.create(
+                name="Staged socket",
+                asset_type="socket",
+                code="SOCK-01",
+                area_id=None,
+                capabilities=[],
+            )
+        )
+
+        with pytest.raises(BindHomeTransactionError, match="active Registry transaction"):
+            async with asyncio.timeout(0.1):
+                await manager.async_create_asset(
+                    name="Nested socket",
+                    asset_type="socket",
+                    code="SOCK-02",
+                    area_id=None,
+                    capabilities=[],
+                )
+
+    assert len(manager.registry.assets) == 1
+
+
+async def test_concurrent_transactions_serialize_without_false_reentry(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    manager._store.async_save = AsyncMock()
+
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def first_mutation() -> None:
+        async with manager.transaction() as staged:
+            staged.add_asset(
+                Asset.create(
+                    name="First",
+                    asset_type="socket",
+                    code="SOCK-01",
+                    area_id=None,
+                    capabilities=[],
+                )
+            )
+            first_entered.set()
+            await release_first.wait()
+
+    async def second_mutation() -> None:
+        await first_entered.wait()
+        await manager.async_create_asset(
+            name="Second",
+            asset_type="socket",
+            code="SOCK-02",
+            area_id=None,
+            capabilities=[],
+        )
+
+    first_task = asyncio.create_task(first_mutation())
+    second_task = asyncio.create_task(second_mutation())
+
+    await first_entered.wait()
+    await asyncio.sleep(0)
+    assert not second_task.done()
+
+    release_first.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert {asset.code for asset in manager.registry.assets.values()} == {
+        "SOCK-01",
+        "SOCK-02",
+    }
+
+
+async def test_transaction_revalidates_staged_registry_before_storage(
+    hass: HomeAssistant,
+) -> None:
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    baseline = manager.registry.to_dict()
+    manager._store.async_save = AsyncMock()
+
+    with pytest.raises(RegistryValidationError, match="was not found"):
+        async with manager.transaction() as staged:
+            relation = Relation.create(
+                source_asset_id="missing-source",
+                relation_type="feeds",
+                target_asset_id="missing-target",
+            )
+            staged.relations[relation.id] = relation
+
+    manager._store.async_save.assert_not_awaited()
+    assert manager.registry.to_dict() == baseline
+
+
+async def test_store_validates_before_touching_home_assistant_storage(
+    hass: HomeAssistant,
+) -> None:
+    store = BindHomeStore(hass)
+    store._store.async_save = AsyncMock()
+    registry = BindHomeRegistry()
+    relation = Relation.create(
+        source_asset_id="missing-source",
+        relation_type="feeds",
+        target_asset_id="missing-target",
+    )
+    registry.relations[relation.id] = relation
+
+    with pytest.raises(RegistryValidationError, match="was not found"):
+        await store.async_save(registry)
+
+    store._store.async_save.assert_not_awaited()
+
+
+def test_registry_replacement_covers_future_persisted_collection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = BindHomeRegistry()
+    source = BindHomeRegistry()
+    target.future_items = {}  # type: ignore[attr-defined]
+    source.future_items = {"future": object()}  # type: ignore[attr-defined]
+
+    original_to_dict = BindHomeRegistry.to_dict
+
+    def to_dict_with_future(self: BindHomeRegistry) -> dict[str, object]:
+        data: dict[str, object] = original_to_dict(self)
+        data["future_items"] = []
+        return data
+
+    monkeypatch.setattr(BindHomeRegistry, "to_dict", to_dict_with_future)
+
+    replace_registry_contents(target, source)
+
+    assert target.future_items == source.future_items  # type: ignore[attr-defined]
+
+
+def test_registry_replacement_fails_closed_for_unhandled_persisted_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = BindHomeRegistry()
+    source = BindHomeRegistry()
+    original_to_dict = BindHomeRegistry.to_dict
+
+    def to_dict_with_scalar(self: BindHomeRegistry) -> dict[str, object]:
+        data: dict[str, object] = original_to_dict(self)
+        data["revision"] = 1
+        return data
+
+    monkeypatch.setattr(BindHomeRegistry, "to_dict", to_dict_with_scalar)
+
+    with pytest.raises(
+        RegistryValidationError,
+        match="explicit adoption semantics: revision",
+    ):
+        replace_registry_contents(target, source)


### PR DESCRIPTION
## Summary

Implements #32 by making the staged Registry transaction boundary a supported `BindHomeManager.transaction()` API instead of a convention built from private manager internals.

- Adds a task-owned mutation lock that serializes concurrent writers but fails fast on same-task re-entry instead of silently deadlocking.
- Adds `manager.transaction()` for isolated staged multi-step mutations with one validate → persist → adopt → signal commit on successful exit.
- Migrates backup restore and dependency-aware Asset deletion away from `_mutation_lock`, `_stage_registry()` and `_async_commit_staged_registry()`.
- Revalidates the complete staged Registry before persistence.
- Makes `BindHomeStore.async_save()` the manager-independent validate-before-write primitive that is also safe for startup canonicalization/migrations.
- Replaces the hand-maintained four-collection adoption block with persisted-collection discovery derived from `Registry.to_dict()`, failing closed for future persisted fields that need explicit non-collection semantics.

## Failure semantics

- An exception inside `manager.transaction()` performs no write and emits no Registry-changed signal.
- Calling a public manager mutation from the same task while a transaction is open raises `BindHomeTransactionError` immediately; it cannot hang on a non-reentrant `asyncio.Lock`.
- Concurrent mutations from different tasks still wait and serialize normally.
- Invalid staged state is rejected before Home Assistant storage is touched.
- Live `BindHomeRegistry` object identity is preserved after commit.

## Tests

Adds focused coverage for successful single-commit transactions, rollback, same-task nested mutation failure, concurrent serialization, pre-storage revalidation, startup-safe store validation, automatic adoption of a simulated future persisted collection, and fail-closed handling of a future persisted scalar field.

Closes #32.