### PR TITLE
feat: add versioned Registry migration policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,14 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 ### Changed
 
 - Registry multi-step mutations now have a supported public `BindHomeManager.transaction()` boundary. Backup restore and dependency-aware Asset deletion use that API instead of reaching into private manager locking/staging/commit internals. ([#62](https://github.com/alessbarb/bindhome/pull/62))
+- Registry schema evolution now uses an explicit stepwise migration layer separate from current-schema model parsing. The real pre-version Registry payload and early schema-v1 payloads that predate explicit Representations are migrated/canonicalized to the current v1 schema without introducing a fake schema bump. ([#63](https://github.com/alessbarb/bindhome/pull/63))
 
 ### Reliability
 
 - Same-task nested manager mutations inside an open Registry transaction now fail immediately with an explicit transaction error instead of being able to deadlock on a non-reentrant `asyncio.Lock`; concurrent mutations from different tasks continue to serialize normally. ([#62](https://github.com/alessbarb/bindhome/pull/62))
 - Staged Registry state is revalidated before persistence, and the manager-independent store write path now validates canonical state before touching Home Assistant storage, giving future startup migrations a documented validate-before-write persistence primitive. ([#62](https://github.com/alessbarb/bindhome/pull/62))
 - Live Registry adoption derives its persisted collection set from the Registry serialization contract instead of maintaining a separate hand-written list, so future persisted collections cannot be silently omitted; new persisted fields without collection semantics fail closed until explicitly handled. ([#62](https://github.com/alessbarb/bindhome/pull/62))
+- Unsupported future Registry schemas fail closed without rewrite, while supported historical Registry schemas—including schemas contained in compatible backup envelopes—are migrated only through explicit validated steps. Golden fixtures and CI require a complete migration path whenever `REGISTRY_SCHEMA_VERSION` is raised. ([#63](https://github.com/alessbarb/bindhome/pull/63))
 
 ---
 

--- a/custom_components/bindhome/backup.py
+++ b/custom_components/bindhome/backup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from .migrations import migrate_registry_payload
 from .registry import BindHomeRegistry, RegistryValidationError
 from .registry_state import replace_registry_contents
 
@@ -28,7 +29,7 @@ def export_registry_backup(registry: BindHomeRegistry) -> dict[str, Any]:
 
 
 def parse_registry_backup(data: object) -> BindHomeRegistry:
-    """Validate a backup envelope and return its isolated Registry."""
+    """Validate a backup envelope and return its current-schema Registry."""
     if not isinstance(data, dict):
         raise BackupValidationError("BindHome backup must be a dictionary")
 
@@ -52,7 +53,7 @@ def parse_registry_backup(data: object) -> BindHomeRegistry:
         raise BackupValidationError("BindHome backup registry must be a dictionary")
 
     try:
-        return BindHomeRegistry.from_dict(registry_data)
+        return migrate_registry_payload(registry_data).registry
     except RegistryValidationError as err:
         raise BackupValidationError(f"Invalid BindHome backup registry: {err}") from err
 

--- a/custom_components/bindhome/migrations.py
+++ b/custom_components/bindhome/migrations.py
@@ -45,9 +45,7 @@ def _read_schema_version(data: dict[str, Any]) -> int:
     if isinstance(raw, bool) or not isinstance(raw, int):
         raise RegistryMigrationError("Registry schema_version must be an integer")
     if raw < LEGACY_REGISTRY_SCHEMA_VERSION:
-        raise RegistryMigrationError(
-            f"Unsupported Registry schema version: {raw}"
-        )
+        raise RegistryMigrationError(f"Unsupported Registry schema version: {raw}")
     return raw
 
 

--- a/custom_components/bindhome/migrations.py
+++ b/custom_components/bindhome/migrations.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 from .const import REGISTRY_SCHEMA_VERSION
 from .registry import BindHomeRegistry, RegistryValidationError

--- a/custom_components/bindhome/migrations.py
+++ b/custom_components/bindhome/migrations.py
@@ -1,0 +1,162 @@
+"""Versioned migration policy for persisted BindHome Registry payloads."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .const import REGISTRY_SCHEMA_VERSION
+from .registry import BindHomeRegistry, RegistryValidationError
+
+LEGACY_REGISTRY_SCHEMA_VERSION = 0
+MIN_SUPPORTED_REGISTRY_SCHEMA_VERSION = LEGACY_REGISTRY_SCHEMA_VERSION
+
+
+class RegistryMigrationError(RegistryValidationError):
+    """Raised when a persisted Registry payload cannot be migrated safely."""
+
+
+class RegistrySchemaFutureError(RegistryMigrationError):
+    """Raised when a Registry payload was written by a newer BindHome schema."""
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryMigrationResult:
+    """Describe canonical Registry state produced from one persisted payload."""
+
+    registry: BindHomeRegistry
+    source_version: int
+    target_version: int
+    changed: bool
+    canonical_payload: dict[str, Any]
+
+
+MigrationStep = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+def _read_schema_version(data: dict[str, Any]) -> int:
+    """Return the explicit schema version or the pre-version legacy marker."""
+    if "schema_version" not in data:
+        return LEGACY_REGISTRY_SCHEMA_VERSION
+
+    raw = data["schema_version"]
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise RegistryMigrationError("Registry schema_version must be an integer")
+    if raw < LEGACY_REGISTRY_SCHEMA_VERSION:
+        raise RegistryMigrationError(
+            f"Unsupported Registry schema version: {raw}"
+        )
+    return raw
+
+
+def _infer_legacy_representations(data: dict[str, Any]) -> list[dict[str, str]]:
+    """Preserve the historical implicit on_off -> light behavior deterministically."""
+    representations: list[dict[str, str]] = []
+    assets = data.get("assets", [])
+    if not isinstance(assets, list):
+        return representations
+
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        asset_id = asset.get("id")
+        capabilities = asset.get("capabilities", [])
+        if asset_id is None or not isinstance(capabilities, (list, tuple)):
+            continue
+        if "on_off" in capabilities:
+            representations.append(
+                {
+                    "asset_id": str(asset_id),
+                    "platform": "light",
+                }
+            )
+    return representations
+
+
+def _migrate_v0_to_v1(data: dict[str, Any]) -> dict[str, Any]:
+    """Migrate the pre-schema legacy payload to Registry schema v1."""
+    migrated = deepcopy(data)
+    migrated["schema_version"] = 1
+    migrated.setdefault("representations", _infer_legacy_representations(migrated))
+    return migrated
+
+
+REGISTRY_MIGRATIONS: dict[int, MigrationStep] = {
+    0: _migrate_v0_to_v1,
+}
+
+
+def _canonicalize_current_payload(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize historically accepted shapes within the current schema version."""
+    canonical = deepcopy(data)
+
+    # Early schema-v1 builds persisted schema_version=1 before Representations
+    # became explicit. Keep that historical shape readable without putting
+    # migration behavior back into BindHomeRegistry.from_dict().
+    if REGISTRY_SCHEMA_VERSION == 1 and "representations" not in canonical:
+        canonical["representations"] = _infer_legacy_representations(canonical)
+
+    return canonical
+
+
+def migrate_registry_payload(data: object) -> RegistryMigrationResult:
+    """Validate version policy, migrate historical payloads and parse canonical state.
+
+    The input object is never mutated. Unsupported future schemas fail before any
+    canonical payload can be persisted. Model validation happens only after all
+    supported version transformations are complete.
+    """
+    if not isinstance(data, dict):
+        raise RegistryMigrationError("Persisted registry must be a dictionary")
+
+    original = deepcopy(data)
+    source_version = _read_schema_version(original)
+
+    if source_version > REGISTRY_SCHEMA_VERSION:
+        raise RegistrySchemaFutureError(
+            "Registry schema version "
+            f"{source_version} is newer than supported version "
+            f"{REGISTRY_SCHEMA_VERSION}"
+        )
+    if source_version < MIN_SUPPORTED_REGISTRY_SCHEMA_VERSION:
+        raise RegistryMigrationError(
+            f"Unsupported historical Registry schema version: {source_version}"
+        )
+
+    canonical = deepcopy(original)
+    version = source_version
+    while version < REGISTRY_SCHEMA_VERSION:
+        step = REGISTRY_MIGRATIONS.get(version)
+        if step is None:
+            raise RegistryMigrationError(
+                "No Registry migration path from schema version "
+                f"{version} to {version + 1}"
+            )
+
+        migrated = step(canonical)
+        next_version = _read_schema_version(migrated)
+        if next_version != version + 1:
+            raise RegistryMigrationError(
+                "Registry migration step did not advance exactly one version: "
+                f"{version} -> {next_version}"
+            )
+        canonical = migrated
+        version = next_version
+
+    canonical = _canonicalize_current_payload(canonical)
+    final_version = _read_schema_version(canonical)
+    if final_version != REGISTRY_SCHEMA_VERSION:
+        raise RegistryMigrationError(
+            "Registry migration did not produce the current schema version"
+        )
+
+    registry = BindHomeRegistry.from_dict(canonical)
+    canonical_payload = registry.to_dict()
+    return RegistryMigrationResult(
+        registry=registry,
+        source_version=source_version,
+        target_version=REGISTRY_SCHEMA_VERSION,
+        changed=canonical_payload != original,
+        canonical_payload=canonical_payload,
+    )

--- a/custom_components/bindhome/migrations.py
+++ b/custom_components/bindhome/migrations.py
@@ -114,9 +114,8 @@ def migrate_registry_payload(data: object) -> RegistryMigrationResult:
 
     if source_version > REGISTRY_SCHEMA_VERSION:
         raise RegistrySchemaFutureError(
-            "Registry schema version "
-            f"{source_version} is newer than supported version "
-            f"{REGISTRY_SCHEMA_VERSION}"
+            f"Unsupported registry schema version: {source_version}; "
+            f"newer than supported version {REGISTRY_SCHEMA_VERSION}"
         )
     if source_version < MIN_SUPPORTED_REGISTRY_SCHEMA_VERSION:
         raise RegistryMigrationError(

--- a/custom_components/bindhome/registry.py
+++ b/custom_components/bindhome/registry.py
@@ -319,7 +319,9 @@ class BindHomeRegistry:
             raise RegistryValidationError("Persisted registry must be a dictionary")
 
         if "schema_version" not in data:
-            raise RegistryValidationError("Persisted registry is missing schema_version")
+            raise RegistryValidationError(
+                "Persisted registry is missing schema_version"
+            )
         schema_version = data["schema_version"]
         if schema_version != REGISTRY_SCHEMA_VERSION:
             raise RegistryValidationError(

--- a/custom_components/bindhome/registry.py
+++ b/custom_components/bindhome/registry.py
@@ -306,24 +306,29 @@ class BindHomeRegistry:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any] | None) -> BindHomeRegistry:
-        """Load and validate a serialized registry."""
+        """Parse and validate only the current canonical Registry schema.
+
+        Historical schema migration belongs in ``migrations.py``. Keeping this
+        parser strict prevents ordinary model parsing from silently changing
+        persisted semantics.
+        """
         registry = cls()
         if data is None:
             return registry
         if not isinstance(data, dict):
             raise RegistryValidationError("Persisted registry must be a dictionary")
 
-        schema_version = data.get("schema_version", REGISTRY_SCHEMA_VERSION)
+        if "schema_version" not in data:
+            raise RegistryValidationError("Persisted registry is missing schema_version")
+        schema_version = data["schema_version"]
         if schema_version != REGISTRY_SCHEMA_VERSION:
             raise RegistryValidationError(
                 f"Unsupported registry schema version: {schema_version}"
             )
-
-        # Persisted registries created before Representation existed have no
-        # "representations" key. Preserve their exact previous runtime
-        # behaviour once by migrating every formerly implicit on_off logical
-        # light to an explicit light Representation.
-        legacy_implicit_representations = "representations" not in data
+        if "representations" not in data:
+            raise RegistryValidationError(
+                "Current registry schema is missing representations"
+            )
 
         for raw_asset in data.get("assets", []):
             try:
@@ -349,26 +354,14 @@ class BindHomeRegistry:
                     f"Invalid binding in registry: {err}"
                 ) from err
 
-        if legacy_implicit_representations:
-            for asset in registry.assets.values():
-                if "on_off" not in asset.capabilities:
-                    continue
-
+        for raw_representation in data.get("representations", []):
+            try:
                 registry.set_representation(
-                    Representation.create(
-                        asset_id=asset.id,
-                        platform="light",
-                    )
+                    Representation.from_dict(raw_representation)
                 )
-        else:
-            for raw_representation in data.get("representations", []):
-                try:
-                    registry.set_representation(
-                        Representation.from_dict(raw_representation)
-                    )
-                except (ModelValidationError, RegistryError) as err:
-                    raise RegistryValidationError(
-                        f"Invalid representation in registry: {err}"
-                    ) from err
+            except (ModelValidationError, RegistryError) as err:
+                raise RegistryValidationError(
+                    f"Invalid representation in registry: {err}"
+                ) from err
 
         return registry

--- a/custom_components/bindhome/registry.py
+++ b/custom_components/bindhome/registry.py
@@ -327,10 +327,6 @@ class BindHomeRegistry:
             raise RegistryValidationError(
                 f"Unsupported registry schema version: {schema_version}"
             )
-        if "representations" not in data:
-            raise RegistryValidationError(
-                "Current registry schema is missing representations"
-            )
 
         for raw_asset in data.get("assets", []):
             try:
@@ -355,6 +351,11 @@ class BindHomeRegistry:
                 raise RegistryValidationError(
                     f"Invalid binding in registry: {err}"
                 ) from err
+
+        if "representations" not in data:
+            raise RegistryValidationError(
+                "Current registry schema is missing representations"
+            )
 
         for raw_representation in data.get("representations", []):
             try:

--- a/custom_components/bindhome/store.py
+++ b/custom_components/bindhome/store.py
@@ -74,7 +74,7 @@ class BindHomeStore:
             ) from err
         except NotImplementedError as err:
             raise BindHomeStoreVersionError(
-                "BindHome storage envelope uses an unsupported older version"
+                "BindHome storage envelope uses an unsupported older storage version"
             ) from err
         except (HomeAssistantError, KeyError, TypeError) as err:
             raise BindHomeStoreLoadError(

--- a/custom_components/bindhome/store.py
+++ b/custom_components/bindhome/store.py
@@ -12,6 +12,7 @@ from homeassistant.util import json as json_util
 from homeassistant.util.file import WriteError
 
 from .const import STORAGE_KEY, STORAGE_VERSION
+from .migrations import RegistrySchemaFutureError, migrate_registry_payload
 from .registry import BindHomeRegistry, RegistryValidationError
 
 
@@ -29,6 +30,10 @@ class BindHomeStoreCorruptionError(BindHomeStoreLoadError):
 
 class BindHomeStoreVersionError(BindHomeStoreLoadError):
     """Raised when the Home Assistant storage envelope is incompatible."""
+
+
+class BindHomeRegistryVersionError(BindHomeStoreLoadError):
+    """Raised when the Registry schema itself is newer than this BindHome."""
 
 
 class _FailFastStore(Store[dict[str, Any]]):
@@ -65,11 +70,11 @@ class BindHomeStore:
             data = await self._store.async_load()
         except UnsupportedStorageVersionError as err:
             raise BindHomeStoreVersionError(
-                "BindHome storage was written by a newer incompatible version"
+                "BindHome storage envelope was written by a newer incompatible version"
             ) from err
         except NotImplementedError as err:
             raise BindHomeStoreVersionError(
-                "BindHome storage uses an unsupported older storage version"
+                "BindHome storage envelope uses an unsupported older version"
             ) from err
         except (HomeAssistantError, KeyError, TypeError) as err:
             raise BindHomeStoreLoadError(
@@ -91,17 +96,20 @@ class BindHomeStore:
             )
 
         try:
-            registry = BindHomeRegistry.from_dict(data)
+            migration = migrate_registry_payload(data)
+        except RegistrySchemaFutureError as err:
+            raise BindHomeRegistryVersionError(str(err)) from err
         except RegistryValidationError as err:
             raise BindHomeStoreLoadError(
                 f"Persisted BindHome registry is invalid: {err}"
             ) from err
 
-        # Startup canonicalization deliberately uses the same manager-independent
-        # validate-before-write persistence primitive as runtime commits. Future
-        # schema migrations can therefore persist a canonical payload without
-        # inventing a third write path before a live manager exists.
-        if "schema_version" not in data or "representations" not in data:
+        registry = migration.registry
+
+        # Startup migration/canonicalization uses the manager-independent
+        # validate-before-write primitive established by the transaction contract.
+        # Failed migration never reaches this write, and failed writes abort setup.
+        if migration.changed:
             await self.async_save(registry)
 
         return registry

--- a/docs/registry-schema.md
+++ b/docs/registry-schema.md
@@ -1,0 +1,63 @@
+# Registry schema and migration policy
+
+BindHome persists two independent version layers and they must not be treated as the same thing.
+
+| Layer | Current value | Owner | Purpose |
+| --- | ---: | --- | --- |
+| Home Assistant storage envelope | `STORAGE_VERSION = 1` | Home Assistant `Store` | Version of the outer `.storage` envelope |
+| BindHome Registry schema | `REGISTRY_SCHEMA_VERSION = 1` | BindHome | Shape and semantics of Assets, Relations, Bindings and Representations |
+
+A storage-envelope incompatibility and a Registry-schema incompatibility are different failure conditions. Code, diagnostics and recovery flows should preserve that distinction.
+
+## Supported Registry version policy
+
+Registry payloads are classified before model parsing:
+
+- **Supported historical schema**: migrated one version at a time through the explicit migration registry until the current schema is reached.
+- **Current canonical schema**: validated and loaded without migration.
+- **Historically accepted non-canonical current shape**: canonicalized explicitly outside the model parser, then validated as the current schema.
+- **Unsupported future schema**: fails closed and is never rewritten by the older BindHome release.
+- **Corrupt or invalid payload**: fails validation; migration code must not guess missing domain data or silently replace it with an empty Registry.
+
+The real pre-version BindHome payload is treated as historical schema `v0`. Its migration to `v1` preserves the old implicit behavior where an Asset with `on_off` was exposed as a logical `light` by writing an explicit Representation. Early `v1` payloads that already declared `schema_version: 1` but predate the `representations` collection are canonicalized with the same deterministic rule.
+
+`BindHomeRegistry.from_dict()` parses only the current canonical schema. Historical transformation belongs in `custom_components/bindhome/migrations.py` so ordinary model parsing cannot silently mutate persisted semantics.
+
+## Migration rules
+
+Every Registry schema bump must:
+
+1. increment `REGISTRY_SCHEMA_VERSION` deliberately;
+2. add a deterministic `vN -> vN+1` migration step;
+3. add or retain a golden fixture for the historical input;
+4. prove that supported historical payloads migrate to the new canonical schema;
+5. prove that unsupported future payloads fail without a write;
+6. prove that a failed migration does not replace or partially rewrite the persisted payload;
+7. update backup/restore and downgrade guidance if compatibility changes.
+
+CI contains a guard that compares the supported historical range with the registered stepwise migrations. Increasing the schema version without adding the required migration step therefore fails the test suite.
+
+Startup migration uses the manager-independent validate-before-write persistence primitive established by the Registry transaction contract. The canonical payload is persisted only after the complete migrated Registry validates successfully.
+
+## Backup restore
+
+The backup envelope and the Registry schema inside it are versioned separately.
+
+A backup with the current backup format may contain a supported historical Registry schema. Restore validates and migrates that Registry to the schema understood by the running BindHome release before it enters the live transaction.
+
+A backup containing an unsupported future Registry schema remains invalid for an older BindHome release and must not be downgraded or rewritten heuristically.
+
+## Downgrade safety
+
+A code downgrade is safe only when the target BindHome release can read the Registry schema currently on disk.
+
+Before installing a release that introduces a newer Registry schema, export and retain a backup created with the older compatible release. Do not assume that reinstalling older Python files makes newer storage readable.
+
+If the current Registry was already written in a schema newer than the target release supports:
+
+- **do not edit Home Assistant `.storage` manually**;
+- do not repeatedly start the older release hoping it will downgrade the file;
+- use a backup whose Registry schema is documented as readable by the target release and the supported BindHome recovery workflow;
+- if the target release predates an in-product recovery path for an unloadable Registry, reinstall the newer compatible BindHome release rather than attempting an unsafe in-place downgrade.
+
+Release notes for any future schema bump must state the new Registry schema version, whether the previous release can still read it, and the exact supported downgrade/recovery procedure.

--- a/docs/release.md
+++ b/docs/release.md
@@ -46,9 +46,17 @@ Generated bundles, formatting-only changes and internal refactors do not need ch
 
 The minimum is not inferred from development history. It must be covered by the Home Assistant compatibility workflow and pass the complete BindHome Python test suite. CI also tests the current supported Home Assistant release so compatibility is checked at both ends of the supported range.
 
-BindHome 1.0.0 supports Home Assistant `2026.8.0` and newer compatible releases. Home Assistant `2026.7.0` is below the supported floor because the BindHome panel uses `homeassistant.components.http.server.StaticPathConfig`, which is unavailable there.
+The BindHome 1.x compatibility baseline starts at Home Assistant `2026.8.0`. Home Assistant `2026.7.0` is below the supported floor because the BindHome panel uses `homeassistant.components.http.server.StaticPathConfig`, which is unavailable there.
 
 When the minimum supported Home Assistant version changes, the HACS metadata, README, compatibility matrix, changelog and release notes must change together.
+
+## Registry schema policy
+
+Home Assistant's storage-envelope version and BindHome's Registry schema version are independent compatibility layers. The complete policy is documented in [`docs/registry-schema.md`](registry-schema.md).
+
+A supported historical Registry schema is migrated one version at a time to the current schema before model parsing. An unsupported future Registry schema fails closed and must never be silently rewritten by an older release. Corrupt or invalid payloads are validation failures, not migration candidates to be guessed or repaired heuristically.
+
+Every future Registry schema bump must include the corresponding stepwise migration test and release/downgrade guidance in the same change.
 
 ## Distribution layout
 
@@ -104,9 +112,11 @@ BindHome storage migrations run through the integration. Do not edit Home Assist
 
 ## Downgrade
 
-Downgrade only to a BindHome release whose documented storage schema can read the current Registry. Use HACS to select the previous release, restart Home Assistant, and verify the integration.
+Downgrade only to a BindHome release whose documented Registry schema can read the Registry currently on disk. A code downgrade does not downgrade persisted data.
 
-If a newer release introduced a storage schema that the older release cannot read, restore a backup created while the older compatible schema was active instead of manipulating `.storage` manually.
+Before any release that bumps the Registry schema, retain a backup created while the older compatible release/schema was active. If the current Registry has already been written in a schema newer than the target release understands, an in-place downgrade is unsafe: use the supported recovery workflow with a backup that the target release can read. If that older target release predates an in-product recovery path for an unloadable Registry, reinstall the newer compatible BindHome release rather than editing `.storage` or repeatedly starting the incompatible version.
+
+See [`docs/registry-schema.md`](registry-schema.md) for the exact version policy and downgrade constraints.
 
 ## Release failure
 
@@ -114,8 +124,8 @@ If installation succeeds but post-restart validation fails:
 
 1. stop making Registry mutations;
 2. capture the BindHome and Home Assistant logs;
-3. reinstall the previous known-good BindHome release through HACS;
+3. reinstall the previous known-good BindHome release through HACS only when its documented Registry schema can read the current data;
 4. restart Home Assistant;
-5. restore a compatible BindHome Registry backup only if required.
+5. restore a compatible BindHome Registry backup only through the supported recovery path if required.
 
 A failed release must never be repaired by changing Home Assistant `.storage` directly.

--- a/tests/fixtures/registry/v0_legacy_implicit_light.json
+++ b/tests/fixtures/registry/v0_legacy_implicit_light.json
@@ -1,0 +1,22 @@
+{
+  "assets": [
+    {
+      "id": "legacy-light",
+      "name": "Legacy light",
+      "asset_type": "light_point",
+      "code": "LGT-OLD",
+      "area_id": "living_room",
+      "capabilities": ["on_off"]
+    },
+    {
+      "id": "legacy-socket",
+      "name": "Legacy socket",
+      "asset_type": "socket",
+      "code": null,
+      "area_id": null,
+      "capabilities": []
+    }
+  ],
+  "relations": [],
+  "bindings": []
+}

--- a/tests/fixtures/registry/v1_canonical.json
+++ b/tests/fixtures/registry/v1_canonical.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "assets": [
+    {
+      "id": "canonical-light",
+      "name": "Canonical light",
+      "asset_type": "light_point",
+      "code": "LGT-01",
+      "area_id": "living_room",
+      "capabilities": ["on_off"]
+    }
+  ],
+  "relations": [],
+  "bindings": [],
+  "representations": [
+    {
+      "asset_id": "canonical-light",
+      "platform": "light"
+    }
+  ]
+}

--- a/tests/test_registry_migrations.py
+++ b/tests/test_registry_migrations.py
@@ -1,0 +1,152 @@
+"""Tests for versioned BindHome Registry schema migration policy."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from custom_components.bindhome.backup import parse_registry_backup
+from custom_components.bindhome.const import REGISTRY_SCHEMA_VERSION
+from custom_components.bindhome.migrations import (
+    MIN_SUPPORTED_REGISTRY_SCHEMA_VERSION,
+    REGISTRY_MIGRATIONS,
+    RegistryMigrationError,
+    RegistrySchemaFutureError,
+    migrate_registry_payload,
+)
+from custom_components.bindhome.registry import BindHomeRegistry, RegistryValidationError
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "registry"
+
+
+def _fixture(name: str) -> dict[str, object]:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def test_current_v1_golden_payload_loads_unchanged() -> None:
+    payload = _fixture("v1_canonical.json")
+
+    result = migrate_registry_payload(payload)
+
+    assert result.source_version == 1
+    assert result.target_version == REGISTRY_SCHEMA_VERSION == 1
+    assert result.changed is False
+    assert result.canonical_payload == payload
+    assert result.registry.to_dict() == payload
+
+
+def test_legacy_v0_golden_payload_migrates_to_current_schema() -> None:
+    payload = _fixture("v0_legacy_implicit_light.json")
+    original = deepcopy(payload)
+
+    result = migrate_registry_payload(payload)
+
+    assert payload == original
+    assert result.source_version == 0
+    assert result.target_version == 1
+    assert result.changed is True
+    assert result.canonical_payload["schema_version"] == 1
+    assert result.canonical_payload["representations"] == [
+        {"asset_id": "legacy-light", "platform": "light"}
+    ]
+    representation = result.registry.get_representation("legacy-light")
+    assert representation is not None
+    assert representation.platform == "light"
+    assert result.registry.get_representation("legacy-socket") is None
+
+
+def test_historical_v1_shape_without_representations_is_canonicalized() -> None:
+    payload = {
+        "schema_version": 1,
+        "assets": [
+            {
+                "id": "old-light",
+                "name": "Old light",
+                "asset_type": "light_point",
+                "capabilities": ["on_off"],
+            }
+        ],
+        "relations": [],
+        "bindings": [],
+    }
+
+    result = migrate_registry_payload(payload)
+
+    assert result.source_version == 1
+    assert result.changed is True
+    assert result.canonical_payload["representations"] == [
+        {"asset_id": "old-light", "platform": "light"}
+    ]
+
+
+def test_migration_is_idempotent_once_payload_is_canonical() -> None:
+    first = migrate_registry_payload(_fixture("v0_legacy_implicit_light.json"))
+    second = migrate_registry_payload(first.canonical_payload)
+
+    assert second.changed is False
+    assert second.canonical_payload == first.canonical_payload
+
+
+def test_future_schema_fails_closed_without_mutating_input() -> None:
+    payload = {
+        "schema_version": REGISTRY_SCHEMA_VERSION + 1,
+        "assets": [],
+        "relations": [],
+        "bindings": [],
+        "representations": [],
+    }
+    original = deepcopy(payload)
+
+    with pytest.raises(RegistrySchemaFutureError, match="newer than supported"):
+        migrate_registry_payload(payload)
+
+    assert payload == original
+
+
+def test_invalid_schema_version_is_not_a_migration_input() -> None:
+    with pytest.raises(RegistryMigrationError, match="must be an integer"):
+        migrate_registry_payload({"schema_version": "1"})
+
+    with pytest.raises(RegistryMigrationError, match="must be an integer"):
+        migrate_registry_payload({"schema_version": True})
+
+
+def test_schema_bump_requires_a_complete_stepwise_migration_path() -> None:
+    expected_steps = set(
+        range(MIN_SUPPORTED_REGISTRY_SCHEMA_VERSION, REGISTRY_SCHEMA_VERSION)
+    )
+
+    assert set(REGISTRY_MIGRATIONS) == expected_steps
+
+
+def test_current_schema_parser_does_not_hide_migration_logic() -> None:
+    with pytest.raises(
+        RegistryValidationError,
+        match="missing representations",
+    ):
+        BindHomeRegistry.from_dict(
+            {
+                "schema_version": 1,
+                "assets": [],
+                "relations": [],
+                "bindings": [],
+            }
+        )
+
+
+def test_backup_restore_parser_migrates_supported_historical_registry() -> None:
+    registry = parse_registry_backup(
+        {
+            "format": "bindhome.registry",
+            "format_version": 1,
+            "registry": _fixture("v0_legacy_implicit_light.json"),
+        }
+    )
+
+    assert registry.to_dict()["schema_version"] == REGISTRY_SCHEMA_VERSION
+    representation = registry.get_representation("legacy-light")
+    assert representation is not None
+    assert representation.platform == "light"

--- a/tests/test_registry_migrations.py
+++ b/tests/test_registry_migrations.py
@@ -17,7 +17,10 @@ from custom_components.bindhome.migrations import (
     RegistrySchemaFutureError,
     migrate_registry_payload,
 )
-from custom_components.bindhome.registry import BindHomeRegistry, RegistryValidationError
+from custom_components.bindhome.registry import (
+    BindHomeRegistry,
+    RegistryValidationError,
+)
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "registry"
 

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -6,6 +6,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from custom_components.bindhome.const import SIGNAL_REGISTRY_CHANGED
 from custom_components.bindhome.manager import BindHomeManager
+from custom_components.bindhome.migrations import migrate_registry_payload
 from custom_components.bindhome.models import Asset, Representation
 from custom_components.bindhome.registry import (
     BindHomeRegistry,
@@ -159,7 +160,7 @@ def test_representation_serialization_roundtrip() -> None:
 
 
 def test_legacy_registry_migrates_implicit_on_off_lights() -> None:
-    legacy = BindHomeRegistry.from_dict(
+    legacy = migrate_registry_payload(
         {
             "schema_version": 1,
             "assets": [
@@ -179,7 +180,7 @@ def test_legacy_registry_migrates_implicit_on_off_lights() -> None:
             "relations": [],
             "bindings": [],
         }
-    )
+    ).registry
 
     representation = legacy.get_representation("old-light")
 
@@ -187,7 +188,7 @@ def test_legacy_registry_migrates_implicit_on_off_lights() -> None:
     assert representation.platform == "light"
     assert legacy.get_representation("old-socket") is None
 
-    # Once serialized by the new model, the distinction becomes explicit.
+    # Once serialized by the current model, the distinction is explicit.
     assert "representations" in legacy.to_dict()
 
 


### PR DESCRIPTION
## Summary

Implements #27 by separating Registry schema migration from model parsing and establishing an explicit, tested version policy.

- Distinguishes the Home Assistant storage envelope version from the BindHome Registry schema version.
- Adds a stepwise `vN -> vN+1` migration registry without inventing schema v2.
- Treats the real pre-schema historical payload as v0 and preserves the historical implicit `on_off -> light` behavior when migrating to canonical v1.
- Canonicalizes early v1 payloads that predate explicit `representations` outside `BindHomeRegistry.from_dict()`.
- Rejects unsupported future schemas fail-closed before any write.
- Migrates supported historical Registry payloads inside backup restore validation.
- Adds golden historical/current fixtures and a guard that fails when a future schema bump lacks a complete stepwise migration path.

## Version policy

- Historical supported schemas: migrate stepwise to current.
- Current schema: parse canonically; historically accepted non-canonical v1 shapes are canonicalized explicitly.
- Future schema: fail closed without rewriting storage.
- Corrupt/invalid payload: fail validation; never treated as migration input to be repaired heuristically.

Closes #27.