### PR TITLE
chore: reconcile 1.2 release baseline on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 
 ## [Unreleased]
 
+### Reliability
+
+- Logical `light` Representations now follow backing-entity state changes through Home Assistant events instead of periodic polling. Rebinding moves the listener to the new target, unavailable/removed states update promptly, and entity removal cleans listeners without duplication. ([#29](https://github.com/alessbarb/bindhome/issues/29))
+- Registry schema v2 adds stable Home Assistant Entity Registry identity to persisted Bindings while retaining `entity_id` as the last-known/state-machine fallback. v1 data and backups migrate deterministically, exact registered targets are enriched before canonical persistence, and unresolved targets are never guessed or silently rebound. ([#50](https://github.com/alessbarb/bindhome/issues/50))
+
+---
+
+## [1.2.0] - 2026-09-05
+
+Second feature release focused on Registry durability, explicit migration and recovery paths, privacy-preserving diagnostics, localization parity and stronger frontend/backend development safety.
+
+**Minimum Home Assistant:** `2026.8.0`
+
 ### Added
 
 - Added privacy-preserving Home Assistant config-entry diagnostics with integration/storage/schema versions, aggregate Registry counts, aggregate Binding resolver statuses and fail-closed recovery context without exporting Registry contents or stable/hardware identifiers. ([#67](https://github.com/alessbarb/bindhome/pull/67))
@@ -31,13 +44,15 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 
 ### Reliability
 
-- Logical `light` Representations now follow backing-entity state changes through Home Assistant events instead of periodic polling. Rebinding moves the listener to the new target, unavailable/removed states update promptly, and entity removal cleans listeners without duplication. ([#29](https://github.com/alessbarb/bindhome/issues/29))
-- Registry schema v2 adds stable Home Assistant Entity Registry identity to persisted Bindings while retaining `entity_id` as the last-known/state-machine fallback. v1 data and backups migrate deterministically, exact registered targets are enriched before canonical persistence, and unresolved targets are never guessed or silently rebound. ([#50](https://github.com/alessbarb/bindhome/issues/50))
 - Registry load failures now enter an explicit fail-closed recovery state with a critical Home Assistant Repair. Administrators can validate and restore a BindHome backup directly to storage even when the normal manager cannot load; successful restore reloads the config entry instead of requiring manual `.storage` edits. ([#65](https://github.com/alessbarb/bindhome/pull/65))
 - Same-task nested manager mutations inside an open Registry transaction now fail immediately with an explicit transaction error instead of being able to deadlock on a non-reentrant `asyncio.Lock`; concurrent mutations from different tasks continue to serialize normally. ([#62](https://github.com/alessbarb/bindhome/pull/62))
 - Staged Registry state is revalidated before persistence, and the manager-independent store write path now validates canonical state before touching Home Assistant storage, giving future startup migrations a documented validate-before-write persistence primitive. ([#62](https://github.com/alessbarb/bindhome/pull/62))
 - Live Registry adoption derives its persisted collection set from the Registry serialization contract instead of maintaining a separate hand-written list, so future persisted collections cannot be silently omitted; new persisted fields without collection semantics fail closed until explicitly handled. ([#62](https://github.com/alessbarb/bindhome/pull/62))
 - Unsupported future Registry schemas fail closed without rewrite, while supported historical Registry schemas—including schemas contained in compatible backup envelopes—are migrated only through explicit validated steps. Golden fixtures and CI require a complete migration path whenever `REGISTRY_SCHEMA_VERSION` is raised. ([#63](https://github.com/alessbarb/bindhome/pull/63))
+
+### Distribution
+
+- Version promoted to `1.2.0` across Python, Home Assistant and frontend package metadata.
 
 ---
 
@@ -169,7 +184,8 @@ First public BindHome release.
 
 ---
 
-[Unreleased]: https://github.com/alessbarb/bindhome/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/alessbarb/bindhome/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/alessbarb/bindhome/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/alessbarb/bindhome/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/alessbarb/bindhome/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/alessbarb/bindhome/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BindHome
 
+**Current stable release: `1.2.0` · Home Assistant `2026.8.0+`**
+
 **Model the home, not the hardware.**
 
 BindHome is a Home Assistant custom integration for describing the **stable physical infrastructure of a home** independently from the smart devices that happen to control or measure it today.
@@ -279,6 +281,14 @@ When the Registry is empty, the panel guides the user through:
 Completing the walkthrough opens **Casa**. From there the user can browse the home or move to **Añadir**, where both single-element and bulk room inventory are available.
 
 Existing installations that already contain Assets do not receive the first-run walkthrough.
+
+---
+
+## BindHome 1.2.0
+
+BindHome 1.2.0 is a reliability-focused release. It keeps the public Registry schema at v1 while making future evolution and recovery safer: multi-step mutations now use a supported manager transaction boundary, historical Registry payloads migrate through explicit validated steps, failed loads expose a fail-closed Home Assistant Repair with backup recovery, and config-entry diagnostics provide aggregate support data without exporting home or hardware identifiers.
+
+The release also enforces English/Spanish translation parity and real JavaScript typechecking for the production panel source. Existing Assets, Relations, Bindings and Representations remain compatible with the 1.1 release line.
 
 ---
 

--- a/custom_components/bindhome/manifest.json
+++ b/custom_components/bindhome/manifest.json
@@ -17,5 +17,5 @@
   "issue_tracker": "https://github.com/alessbarb/bindhome/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.1.1"
+  "version": "1.2.0"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bindhome-panel",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bindhome-panel",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "lit": "^3.3.3"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bindhome-panel",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bindhome"
-version = "1.1.1"
+version = "1.2.0"
 description = "Stable home infrastructure bound to replaceable Home Assistant hardware"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -101,7 +101,7 @@ async def test_loaded_config_entry_diagnostics_snapshot(monkeypatch) -> None:
     monkeypatch.setattr(
         diagnostics,
         "async_get_integration",
-        AsyncMock(return_value=SimpleNamespace(version="1.1.1")),
+        AsyncMock(return_value=SimpleNamespace(version="1.2.0")),
     )
     monkeypatch.setattr(
         diagnostics,
@@ -121,7 +121,7 @@ async def test_loaded_config_entry_diagnostics_snapshot(monkeypatch) -> None:
 
     assert result == {
         "integration": {
-            "version": "1.1.1",
+            "version": "1.2.0",
             "storage_version": 1,
             "registry_schema_version": REGISTRY_SCHEMA_VERSION,
         },
@@ -171,7 +171,7 @@ async def test_degraded_diagnostics_expose_reason_without_registry_or_message(
     monkeypatch.setattr(
         diagnostics,
         "async_get_integration",
-        AsyncMock(return_value=SimpleNamespace(version="1.1.1")),
+        AsyncMock(return_value=SimpleNamespace(version="1.2.0")),
     )
     monkeypatch.setattr(
         diagnostics,
@@ -217,7 +217,7 @@ async def test_diagnostics_redact_asset_codes_names_and_entity_ids(monkeypatch) 
     monkeypatch.setattr(
         diagnostics,
         "async_get_integration",
-        AsyncMock(return_value=SimpleNamespace(version="1.1.1")),
+        AsyncMock(return_value=SimpleNamespace(version="1.2.0")),
     )
     monkeypatch.setattr(
         diagnostics,


### PR DESCRIPTION
## Summary

Reconciles the published BindHome 1.2.0 release baseline back onto the current development `main` without removing or changing the already-merged 1.3 work.

- Restores `1.2.0` as the current package/manifest/frontend metadata baseline.
- Restores the finalized `1.2.0` changelog section from the published release.
- Keeps only the already-merged 1.3 work (#29 and #50) under `Unreleased`.
- Restores the BindHome 1.2.0 README release note.
- Updates diagnostics version expectations to the reconciled package baseline.
- Preserves Registry schema v2, stable Binding target identity, and event-driven logical lights unchanged.

## Why

`v1.2.0` was published from `release/1.2.0`, while `main` continued from the pre-release merge base and already accepted 1.3 work. As a result, the public tag is correct but `main` still reports `1.1.1` and its changelog mixes released 1.2 entries with unreleased 1.3 entries.

This PR performs a semantic reconciliation rather than merging the diverged release branch wholesale.

## Scope

No runtime behavior, Registry migration logic, Binding semantics, Representation behavior, frontend bundle, Home Assistant compatibility floor, or persisted user data is changed.