### PR TITLE
feat: resolve Bindings through stable Entity Registry identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 
 ### Reliability
 
+- Binding resolution now treats persisted Home Assistant Entity Registry entry identity as authoritative, resolving the current `entity_id` at read time so normal HA renames stay transparent. Removed Registry entries fail stale without falling back to a potentially reused entity name; state-machine-only targets retain the explicit `entity_id` fallback. ([#51](https://github.com/alessbarb/bindhome/issues/51))
 - Logical `light` Representations now follow backing-entity state changes through Home Assistant events instead of periodic polling. Rebinding moves the listener to the new target, unavailable/removed states update promptly, and entity removal cleans listeners without duplication. ([#29](https://github.com/alessbarb/bindhome/issues/29))
 - Registry schema v2 adds stable Home Assistant Entity Registry identity to persisted Bindings while retaining `entity_id` as the last-known/state-machine fallback. v1 data and backups migrate deterministically, exact registered targets are enriched before canonical persistence, and unresolved targets are never guessed or silently rebound. ([#50](https://github.com/alessbarb/bindhome/issues/50))
 

--- a/custom_components/bindhome/resolver.py
+++ b/custom_components/bindhome/resolver.py
@@ -8,11 +8,16 @@ Central operation::
 
     (asset_id, capability, role) -> current Home Assistant entity_id
 
+For registered Home Assistant entities, BindHome treats the persisted Entity
+Registry entry id as authoritative and resolves the current mutable ``entity_id``
+at read time. ``Binding.entity_id`` remains a last-known display value and the
+explicit fallback for state-machine-only entities.
+
 Two independent axes are reported:
 
-* configuration validity -- the binding exists and its entity reference still
-  points at something Home Assistant knows about (Entity Registry or state
-  machine). A device that is merely offline is still a valid configuration.
+* configuration validity -- the binding exists and its stable/fallback entity
+  reference still points at something Home Assistant knows about. A device that
+  is merely offline is still a valid configuration.
 * runtime availability -- the entity currently has a usable state, i.e. not
   ``unavailable``, ``unknown`` or missing from the state machine.
 
@@ -106,7 +111,11 @@ class Resolution:
 
 
 class EntityProbe(Protocol):
-    """Read-only view of Home Assistant entity existence and state."""
+    """Read-only view of Home Assistant entity identity, existence and state."""
+
+    def resolve_registry_entity_id(self, entity_registry_id: str) -> str | None:
+        """Return the current entity_id for one stable Registry entry id."""
+        ...
 
     def is_known(self, entity_id: str) -> bool:
         """Return True if the entity exists in the registry or state machine."""
@@ -119,19 +128,26 @@ class EntityProbe(Protocol):
 class StaticEntityProbe:
     """In-memory :class:`EntityProbe` for tests and offline evaluation.
 
-    ``registered`` is the set of entity ids present in the Entity Registry.
-    ``states`` maps entity ids present in the state machine to their state
-    string. The union models Home Assistant's "entity exists" definition.
+    ``registry_entries`` maps stable Entity Registry entry ids to their current
+    mutable entity ids. ``registered`` remains a convenience for tests that only
+    care about entity-id existence. ``states`` maps entity ids present in the
+    state machine to their state string.
     """
 
     def __init__(
         self,
         *,
+        registry_entries: dict[str, str] | None = None,
         registered: set[str] | None = None,
         states: dict[str, str] | None = None,
     ) -> None:
+        self.registry_entries: dict[str, str] = dict(registry_entries or {})
         self.registered: set[str] = set(registered or set())
+        self.registered.update(self.registry_entries.values())
         self.states: dict[str, str] = dict(states or {})
+
+    def resolve_registry_entity_id(self, entity_registry_id: str) -> str | None:
+        return self.registry_entries.get(entity_registry_id)
 
     def is_known(self, entity_id: str) -> bool:
         return entity_id in self.registered or entity_id in self.states
@@ -143,12 +159,18 @@ class StaticEntityProbe:
 class HomeAssistantEntityProbe:
     """:class:`EntityProbe` backed by a live Home Assistant instance.
 
-    "Entity exists" matches the existing definition in ``services.py``: present
-    in the Entity Registry or in the state machine.
+    Stable Registry lookups use Home Assistant's own Entity Registry entry id;
+    state-machine-only entities retain the existing entity-id fallback.
     """
 
     def __init__(self, hass: HomeAssistant) -> None:
         self._hass = hass
+
+    def resolve_registry_entity_id(self, entity_registry_id: str) -> str | None:
+        from homeassistant.helpers import entity_registry as er
+
+        entry = er.async_get(self._hass).entities.get_entry(entity_registry_id)
+        return entry.entity_id if entry is not None else None
 
     def is_known(self, entity_id: str) -> bool:
         from homeassistant.helpers import entity_registry as er
@@ -205,16 +227,35 @@ class BindingResolver:
                 asset_id, capability, role, ResolutionStatus.BINDING_NOT_FOUND
             )
 
-        entity_id = binding.entity_id
-        if not self._probe.is_known(entity_id):
-            return Resolution(
-                asset_id=asset_id,
-                capability=capability,
-                role=role,
-                status=ResolutionStatus.ENTITY_NOT_FOUND,
-                binding=binding,
-                entity_id=entity_id,
+        if binding.entity_registry_id is not None:
+            entity_id = self._probe.resolve_registry_entity_id(
+                binding.entity_registry_id
             )
+            if entity_id is None:
+                # A stable Registry target must never fall back to the stored
+                # mutable entity_id: that name may already belong to another
+                # Registry entry after removal/reuse.
+                return Resolution(
+                    asset_id=asset_id,
+                    capability=capability,
+                    role=role,
+                    status=ResolutionStatus.ENTITY_NOT_FOUND,
+                    binding=binding,
+                    entity_id=None,
+                )
+        else:
+            # Explicit compatibility path for state-machine-only entities and
+            # legacy targets that do not have a Registry entry identity.
+            entity_id = binding.entity_id
+            if not self._probe.is_known(entity_id):
+                return Resolution(
+                    asset_id=asset_id,
+                    capability=capability,
+                    role=role,
+                    status=ResolutionStatus.ENTITY_NOT_FOUND,
+                    binding=binding,
+                    entity_id=entity_id,
+                )
 
         state = self._probe.get_state(entity_id)
         status = _runtime_status(state)
@@ -253,6 +294,12 @@ class BindingResolver:
                 f"No binding for ({asset_id}, {capability}, {role})"
             )
         if result.status is ResolutionStatus.ENTITY_NOT_FOUND:
+            binding = result.binding
+            if binding is not None and binding.entity_registry_id is not None:
+                raise StaleBindingError(
+                    "Bound Entity Registry entry "
+                    f"{binding.entity_registry_id} no longer exists"
+                )
             raise StaleBindingError(f"Bound entity {result.entity_id} no longer exists")
         assert result.entity_id is not None
         return result.entity_id

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,7 @@
 """Tests for the BindHome binding resolver and compatibility layer."""
 
 import pytest
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.bindhome.models import Asset, Binding
 from custom_components.bindhome.registry import BindHomeRegistry
@@ -34,9 +35,17 @@ def _bind(
     cap: str,
     entity: str,
     role: str = "primary",
+    *,
+    entity_registry_id: str | None = None,
 ) -> Binding:
     return registry.set_binding(
-        Binding.create(asset_id=asset.id, capability=cap, entity_id=entity, role=role)
+        Binding.create(
+            asset_id=asset.id,
+            capability=cap,
+            entity_id=entity,
+            entity_registry_id=entity_registry_id,
+            role=role,
+        )
     )
 
 
@@ -79,8 +88,10 @@ def test_registry_only_target_is_valid_config_but_not_runtime_available() -> Non
 def test_both_probe_implementations_satisfy_the_entity_probe_protocol() -> None:
     static_probe: EntityProbe = StaticEntityProbe(states={"switch.relay": "on"})
     ha_probe: EntityProbe = HomeAssistantEntityProbe.__new__(HomeAssistantEntityProbe)
+    assert static_probe.resolve_registry_entity_id("missing") is None
     assert static_probe.is_known("switch.relay") is True
     assert static_probe.get_state("switch.relay") == "on"
+    assert callable(ha_probe.resolve_registry_entity_id)
     assert callable(ha_probe.is_known)
     assert callable(ha_probe.get_state)
 
@@ -190,6 +201,112 @@ def test_malformed_request_is_reported_not_masked_as_missing_capability() -> Non
     assert result.status is ResolutionStatus.INVALID_REQUEST
     with pytest.raises(InvalidResolveRequestError):
         resolver.resolve_entity_id(asset.id, "on off")
+
+
+# --- stable Entity Registry target identity -------------------------------
+
+
+def test_stable_registry_target_resolves_current_entity_id_after_rename() -> None:
+    registry = BindHomeRegistry()
+    asset = _asset(registry, ["on_off"])
+    binding = _bind(
+        registry,
+        asset,
+        "on_off",
+        "switch.before_rename",
+        entity_registry_id="entry-123",
+    )
+    probe = StaticEntityProbe(
+        registry_entries={"entry-123": "switch.after_rename"},
+        states={"switch.after_rename": "on"},
+    )
+    resolver = BindingResolver(registry, probe)
+
+    result = resolver.resolve(asset.id, "on_off")
+
+    assert result.status is ResolutionStatus.RESOLVED
+    assert result.entity_id == "switch.after_rename"
+    assert result.state == "on"
+    assert result.binding is binding
+    assert result.binding.entity_registry_id == "entry-123"
+    # Persisted entity_id is deliberately only the last-known value.
+    assert result.binding.entity_id == "switch.before_rename"
+    assert resolver.resolve_entity_id(asset.id, "on_off") == "switch.after_rename"
+
+
+def test_missing_stable_registry_entry_never_falls_back_to_reused_entity_id() -> None:
+    registry = BindHomeRegistry()
+    asset = _asset(registry, ["on_off"])
+    _bind(
+        registry,
+        asset,
+        "on_off",
+        "switch.reused_name",
+        entity_registry_id="removed-entry",
+    )
+    probe = StaticEntityProbe(
+        # Another Registry entry now owns the old mutable entity_id.
+        registry_entries={"different-entry": "switch.reused_name"},
+        states={"switch.reused_name": "on"},
+    )
+    resolver = BindingResolver(registry, probe)
+
+    result = resolver.resolve(asset.id, "on_off")
+
+    assert result.status is ResolutionStatus.ENTITY_NOT_FOUND
+    assert result.entity_id is None
+    assert result.binding is not None
+    assert result.binding.entity_id == "switch.reused_name"
+    assert result.config_valid is False
+    with pytest.raises(StaleBindingError, match="removed-entry"):
+        resolver.resolve_entity_id(asset.id, "on_off")
+
+
+def test_stable_registry_target_is_valid_even_without_runtime_state() -> None:
+    registry = BindHomeRegistry()
+    asset = _asset(registry, ["on_off"])
+    _bind(
+        registry,
+        asset,
+        "on_off",
+        "switch.old_name",
+        entity_registry_id="entry-offline",
+    )
+    resolver = BindingResolver(
+        registry,
+        StaticEntityProbe(registry_entries={"entry-offline": "switch.current_name"}),
+    )
+
+    result = resolver.resolve(asset.id, "on_off")
+
+    assert result.status is ResolutionStatus.RUNTIME_UNAVAILABLE
+    assert result.entity_id == "switch.current_name"
+    assert result.config_valid is True
+    assert resolver.resolve_entity_id(asset.id, "on_off") == "switch.current_name"
+
+
+async def test_home_assistant_probe_resolves_registry_uuid_after_entity_rename(
+    hass,
+) -> None:
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get_or_create(
+        "switch",
+        "demo",
+        "stable-target",
+        suggested_object_id="before_rename",
+    )
+    registry_entry_id = entry.id
+    old_entity_id = entry.entity_id
+    renamed = entity_registry.async_update_entity(
+        old_entity_id,
+        new_entity_id="switch.after_rename",
+    )
+
+    probe = HomeAssistantEntityProbe(hass)
+
+    assert renamed.id == registry_entry_id
+    assert probe.resolve_registry_entity_id(registry_entry_id) == "switch.after_rename"
+    assert probe.resolve_registry_entity_id("missing-entry") is None
 
 
 # --- replacement / identity semantics ------------------------------------


### PR DESCRIPTION
## Summary

Implements #51 on top of the 1.2 baseline reconciliation.

- Resolves registered Binding targets through the persisted Home Assistant Entity Registry entry ID at read time.
- Uses Home Assistant's indexed `entity_registry.entities.get_entry(entry_id)` API, available in the supported 2026.8.0 baseline.
- Treats the stable Registry entry identity as authoritative: if that entry is gone, the Binding becomes stale and never falls back to a potentially reused old `entity_id`.
- Keeps `Binding.entity_id` as the explicit compatibility path for state-machine-only targets that have no Entity Registry identity.
- Returns the current mutable `entity_id` after a normal Home Assistant rename without persisting a Registry mutation.
- Extends the probe contract and deterministic static probe used by read-model/tests.

## Tests

Adds coverage for:

- resolution before/after an Entity Registry rename;
- stable UUID preserved while the current `entity_id` changes;
- removed stable Registry entry becoming stale;
- reuse of the old `entity_id` by another Registry entry not retargeting the Binding;
- registered target with no current runtime state remaining configuration-valid;
- state-machine-only fallback behavior remaining unchanged;
- Home Assistant Entity Registry UUID lookup using the real registry fixture.

## Compatibility

No persisted Registry shape changes are introduced here; schema v2 from #50 is reused. No Home Assistant Registry entry is modified by resolution.

Closes #51 once merged to `main`.