### PR TITLE
fix: preserve logical light capabilities and surface failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 
 ### Changed
 
+- Logical `light` Representations now mirror supported Home Assistant light capabilities from their current backing `light` entity, including brightness/color metadata and supported transition/effect features, while non-light targets remain ON/OFF-only. Light service parameters are forwarded to backing lights, rebinding refreshes advertised capabilities without changing logical identity, and unresolved or unavailable commands now raise a visible Home Assistant error instead of succeeding as silent no-ops. ([#30](https://github.com/alessbarb/bindhome/issues/30))
 - Stable Binding target identity is now reflected consistently across backup/restore, typed frontend contracts, Advanced infrastructure inspection and the normative architecture/product documentation. Normal connection UI continues to show the current resolved Home Assistant `entity_id`, while technical surfaces can inspect the stable Entity Registry entry identity and last-known fallback. ([#53](https://github.com/alessbarb/bindhome/issues/53))
 
 ### Reliability

--- a/custom_components/bindhome/light.py
+++ b/custom_components/bindhome/light.py
@@ -342,7 +342,9 @@ class BindHomeLight(LightEntity):
         self._attr_brightness = brightness if isinstance(brightness, int) else None
 
         color_temp = attributes.get("color_temp_kelvin")
-        self._attr_color_temp_kelvin = color_temp if isinstance(color_temp, int) else None
+        self._attr_color_temp_kelvin = (
+            color_temp if isinstance(color_temp, int) else None
+        )
         min_color_temp = attributes.get("min_color_temp_kelvin")
         self._attr_min_color_temp_kelvin = (
             min_color_temp if isinstance(min_color_temp, int) else None

--- a/custom_components/bindhome/light.py
+++ b/custom_components/bindhome/light.py
@@ -46,7 +46,7 @@ def _color_mode(value: Any) -> ColorMode | None:
     """Coerce one Home Assistant state attribute to a known color mode."""
     try:
         mode = ColorMode(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
     return None if mode is ColorMode.UNKNOWN else mode
 
@@ -57,11 +57,7 @@ def _supported_color_modes(attributes: dict[str, Any]) -> set[ColorMode]:
     if not isinstance(raw_modes, (list, tuple, set, frozenset)):
         return {ColorMode.ONOFF}
 
-    modes = {
-        mode
-        for value in raw_modes
-        if (mode := _color_mode(value)) is not None
-    }
+    modes = {mode for value in raw_modes if (mode := _color_mode(value)) is not None}
     if not modes:
         return {ColorMode.ONOFF}
 
@@ -81,7 +77,7 @@ def _tuple_value(
         return None
     try:
         return tuple(caster(item) for item in value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
 
 
@@ -334,7 +330,7 @@ class BindHomeLight(LightEntity):
         raw_features = attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         try:
             features = LightEntityFeature(int(raw_features))
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             features = LightEntityFeature(0)
         self._attr_supported_features = features & _KNOWN_LIGHT_FEATURES
 

--- a/custom_components/bindhome/light.py
+++ b/custom_components/bindhome/light.py
@@ -6,8 +6,15 @@ import asyncio
 from collections.abc import Callable
 from typing import Any
 
-from homeassistant.components.light import ColorMode, LightEntity
+from homeassistant.components.light import (
+    ColorMode,
+    LightEntity,
+    LightEntityFeature,
+    filter_supported_color_modes,
+)
+from homeassistant.const import ATTR_SUPPORTED_FEATURES
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -24,6 +31,9 @@ from .resolver import (
 )
 
 _CAPABILITY = "on_off"
+_KNOWN_LIGHT_FEATURES = (
+    LightEntityFeature.EFFECT | LightEntityFeature.FLASH | LightEntityFeature.TRANSITION
+)
 
 
 def _entity_registry_id(asset_id: str) -> tuple[str, str, str]:
@@ -34,6 +44,45 @@ def _entity_registry_id(asset_id: str) -> tuple[str, str, str]:
     if contract is None:
         raise ValueError("Missing runtime contract for light representation")
     return contract.domain, DOMAIN, contract.unique_id
+
+
+def _color_mode(value: Any) -> ColorMode | None:
+    """Coerce one Home Assistant state attribute to a known color mode."""
+    try:
+        mode = ColorMode(value)
+    except (TypeError, ValueError):
+        return None
+    return None if mode is ColorMode.UNKNOWN else mode
+
+
+def _supported_color_modes(attributes: dict[str, Any]) -> set[ColorMode]:
+    """Return a safe advertised mode set from a backing light state."""
+    raw_modes = attributes.get("supported_color_modes")
+    if not isinstance(raw_modes, (list, tuple, set, frozenset)):
+        return {ColorMode.ONOFF}
+
+    modes = {
+        mode
+        for value in raw_modes
+        if (mode := _color_mode(value)) is not None
+    }
+    if not modes:
+        return {ColorMode.ONOFF}
+
+    try:
+        return filter_supported_color_modes(modes)
+    except HomeAssistantError:
+        return {ColorMode.ONOFF}
+
+
+def _tuple_value(value: Any, length: int, caster: type[int] | type[float]) -> tuple | None:
+    """Return a typed tuple from one state attribute when structurally valid."""
+    if not isinstance(value, (list, tuple)) or len(value) != length:
+        return None
+    try:
+        return tuple(caster(item) for item in value)
+    except (TypeError, ValueError):
+        return None
 
 
 async def async_setup_entry(
@@ -126,8 +175,6 @@ class BindHomeLight(LightEntity):
     """A stable logical light backed by the asset's current binding."""
 
     _attr_should_poll = False
-    _attr_color_mode = ColorMode.ONOFF
-    _attr_supported_color_modes = {ColorMode.ONOFF}
 
     def __init__(
         self, hass: HomeAssistant, asset: Asset, resolver: BindingResolver
@@ -143,6 +190,7 @@ class BindHomeLight(LightEntity):
         self._attr_unique_id = _entity_registry_id(asset.id)[2]
         self._attr_available = False
         self._attr_is_on = None
+        self._reset_light_capabilities()
 
     @property
     def asset_id(self) -> str:
@@ -242,6 +290,82 @@ class BindHomeLight(LightEntity):
             if resolution.runtime_available and state in {"on", "off"}
             else None
         )
+        self._apply_backing_light_capabilities(resolution.entity_id)
+
+    def _reset_light_capabilities(self) -> None:
+        """Expose only safe ON/OFF semantics for a non-light or unknown target."""
+        self._attr_supported_color_modes = {ColorMode.ONOFF}
+        self._attr_color_mode = ColorMode.ONOFF
+        self._attr_supported_features = LightEntityFeature(0)
+        self._attr_brightness = None
+        self._attr_color_temp_kelvin = None
+        self._attr_min_color_temp_kelvin = None
+        self._attr_max_color_temp_kelvin = None
+        self._attr_hs_color = None
+        self._attr_rgb_color = None
+        self._attr_rgbw_color = None
+        self._attr_rgbww_color = None
+        self._attr_xy_color = None
+        self._attr_effect = None
+        self._attr_effect_list = None
+
+    def _apply_backing_light_capabilities(self, entity_id: str | None) -> None:
+        """Mirror the current backing light's safe Home Assistant capabilities."""
+        self._reset_light_capabilities()
+        if entity_id is None or not entity_id.startswith("light."):
+            return
+
+        backing_state = self.hass.states.get(entity_id)
+        if backing_state is None:
+            return
+
+        attributes = backing_state.attributes
+        modes = _supported_color_modes(attributes)
+        self._attr_supported_color_modes = modes
+
+        current_mode = _color_mode(attributes.get("color_mode"))
+        if current_mode in modes:
+            self._attr_color_mode = current_mode
+        elif len(modes) == 1:
+            self._attr_color_mode = next(iter(modes))
+        else:
+            self._attr_color_mode = None
+
+        raw_features = attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        try:
+            features = LightEntityFeature(int(raw_features))
+        except (TypeError, ValueError):
+            features = LightEntityFeature(0)
+        self._attr_supported_features = features & _KNOWN_LIGHT_FEATURES
+
+        brightness = attributes.get("brightness")
+        self._attr_brightness = brightness if isinstance(brightness, int) else None
+
+        color_temp = attributes.get("color_temp_kelvin")
+        self._attr_color_temp_kelvin = color_temp if isinstance(color_temp, int) else None
+        min_color_temp = attributes.get("min_color_temp_kelvin")
+        self._attr_min_color_temp_kelvin = (
+            min_color_temp if isinstance(min_color_temp, int) else None
+        )
+        max_color_temp = attributes.get("max_color_temp_kelvin")
+        self._attr_max_color_temp_kelvin = (
+            max_color_temp if isinstance(max_color_temp, int) else None
+        )
+
+        self._attr_hs_color = _tuple_value(attributes.get("hs_color"), 2, float)
+        self._attr_xy_color = _tuple_value(attributes.get("xy_color"), 2, float)
+        self._attr_rgb_color = _tuple_value(attributes.get("rgb_color"), 3, int)
+        self._attr_rgbw_color = _tuple_value(attributes.get("rgbw_color"), 4, int)
+        self._attr_rgbww_color = _tuple_value(attributes.get("rgbww_color"), 5, int)
+
+        if LightEntityFeature.EFFECT in self._attr_supported_features:
+            effect = attributes.get("effect")
+            self._attr_effect = effect if isinstance(effect, str) else None
+            effect_list = attributes.get("effect_list")
+            if isinstance(effect_list, (list, tuple)) and all(
+                isinstance(item, str) for item in effect_list
+            ):
+                self._attr_effect_list = list(effect_list)
 
     def _unsubscribe_backing_state(self) -> None:
         """Remove the current backing state listener exactly once."""
@@ -255,23 +379,38 @@ class BindHomeLight(LightEntity):
         self._apply_resolution(self._resolver.resolve(self._asset.id, _CAPABILITY))
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Forward turn-on to the currently bound switch or light."""
-        await self._async_forward("turn_on")
+        """Forward turn-on and supported light kwargs to the current target."""
+        await self._async_forward("turn_on", kwargs)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Forward turn-off to the currently bound switch or light."""
-        await self._async_forward("turn_off")
+        """Forward turn-off and supported light kwargs to the current target."""
+        await self._async_forward("turn_off", kwargs)
 
-    async def _async_forward(self, service: str) -> None:
+    async def _async_forward(self, service: str, kwargs: dict[str, Any]) -> None:
+        """Forward one command or raise a Home Assistant-visible runtime error."""
         resolution = self._resolver.resolve(self._asset.id, _CAPABILITY)
-        self._resolution = resolution
+        self._apply_resolution(resolution)
         entity_id = resolution.entity_id
         if resolution.status is not ResolutionStatus.RESOLVED or entity_id is None:
-            return
+            target = entity_id
+            if target is None and resolution.binding is not None:
+                target = resolution.binding.entity_id
+            target_label = target or "configured target"
+            raise HomeAssistantError(
+                f"BindHome cannot {service.replace('_', ' ')} {self._asset.name}: "
+                f"backing entity {target_label} is {resolution.status.value}"
+            )
+
+        service_data: dict[str, Any] = {"entity_id": entity_id}
+        if entity_id.startswith("light."):
+            service_domain = "light"
+            service_data.update(kwargs)
+        else:
+            service_domain = "homeassistant"
 
         await self.hass.services.async_call(
-            "homeassistant",
+            service_domain,
             service,
-            {"entity_id": entity_id},
+            service_data,
             blocking=True,
         )

--- a/custom_components/bindhome/light.py
+++ b/custom_components/bindhome/light.py
@@ -24,11 +24,7 @@ from .const import DOMAIN, SIGNAL_BINDING_TARGET_CHANGED, SIGNAL_REGISTRY_CHANGE
 from .manager import BindHomeManager
 from .models import Asset, Representation
 from .representation import runtime_contract
-from .resolver import (
-    BindingResolver,
-    Resolution,
-    ResolutionStatus,
-)
+from .resolver import BindingResolver, Resolution, ResolutionStatus
 
 _CAPABILITY = "on_off"
 _KNOWN_LIGHT_FEATURES = (
@@ -75,7 +71,11 @@ def _supported_color_modes(attributes: dict[str, Any]) -> set[ColorMode]:
         return {ColorMode.ONOFF}
 
 
-def _tuple_value(value: Any, length: int, caster: type[int] | type[float]) -> tuple | None:
+def _tuple_value(
+    value: Any,
+    length: int,
+    caster: type[int] | type[float],
+) -> tuple[Any, ...] | None:
     """Return a typed tuple from one state attribute when structurally valid."""
     if not isinstance(value, (list, tuple)) or len(value) != length:
         return None
@@ -358,7 +358,7 @@ class BindHomeLight(LightEntity):
         self._attr_rgbw_color = _tuple_value(attributes.get("rgbw_color"), 4, int)
         self._attr_rgbww_color = _tuple_value(attributes.get("rgbww_color"), 5, int)
 
-        if LightEntityFeature.EFFECT in self._attr_supported_features:
+        if self._attr_supported_features & LightEntityFeature.EFFECT:
             effect = attributes.get("effect")
             self._attr_effect = effect if isinstance(effect, str) else None
             effect_list = attributes.get("effect_list")

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -288,6 +288,12 @@ Replacing hardware should not require changing automations that target the stabl
 
 Renaming the currently bound registered Home Assistant entity also must not require changing the BindHome logical entity or Binding. Logical runtime consumers follow the stable Binding target to its current `entity_id`.
 
+A logical `light` owns its stable BindHome identity, name/location metadata and the fact that it is exposed as a Light. It does not invent hardware light features. When its resolved backing target is another Home Assistant `light`, BindHome mirrors the backing light's currently advertised color modes, brightness/color state and supported Light features such as transition/effect, and forwards supported `turn_on`/`turn_off` service parameters through Home Assistant. Rebinding recalculates those advertised capabilities without changing the logical entity identity.
+
+When the resolved target is not a Home Assistant `light`, the logical Representation exposes only safe ON/OFF semantics and delegates generic turn services to Home Assistant. BindHome does not maintain a parallel cross-domain compatibility catalogue or emulate brightness/color capabilities that the backing entity does not provide.
+
+Logical operations must fail visibly when the Binding cannot resolve to an available runtime target. An unresolved, stale, unavailable or unknown backing entity must not turn a requested operation into a silent successful no-op.
+
 Logical operations resolve the current Binding and delegate execution to Home Assistant services. Home Assistant remains responsible for actual platform and hardware behaviour.
 
 ## Compatibility contract

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 from homeassistant.components.light import ColorMode
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from custom_components.bindhome.light import BindHomeLight
@@ -123,7 +124,7 @@ async def test_logical_light_is_safely_unavailable_for_degraded_binding(
     assert logical.is_on is None
 
 
-async def test_logical_light_does_not_forward_missing_binding(
+async def test_logical_light_raises_for_missing_binding(
     hass: HomeAssistant,
 ) -> None:
     registry = BindHomeRegistry()
@@ -134,7 +135,8 @@ async def test_logical_light_does_not_forward_missing_binding(
 
     logical = _logical_light(hass, registry, asset)
 
-    await logical.async_turn_on()
+    with pytest.raises(HomeAssistantError, match="binding_not_found"):
+        await logical.async_turn_on()
 
     assert calls.await_count == 0
 

--- a/tests/test_light_capability_proxy.py
+++ b/tests/test_light_capability_proxy.py
@@ -1,0 +1,212 @@
+"""Capability-fidelity tests for BindHome logical light Representations."""
+
+import pytest
+from homeassistant.components.light import ColorMode, LightEntityFeature
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.bindhome.light import BindHomeLight
+from custom_components.bindhome.models import Asset, Binding
+from custom_components.bindhome.registry import BindHomeRegistry
+from custom_components.bindhome.resolver import BindingResolver, HomeAssistantEntityProbe
+
+
+def _setup(registry: BindHomeRegistry, hass: HomeAssistant, entity_id: str) -> BindHomeLight:
+    asset = registry.add_asset(
+        Asset.create(
+            name="Proxy light",
+            asset_type="light_point",
+            capabilities=["on_off"],
+        )
+    )
+    registry.set_binding(
+        Binding.create(
+            asset_id=asset.id,
+            capability="on_off",
+            entity_id=entity_id,
+        )
+    )
+    return BindHomeLight(
+        hass,
+        asset,
+        BindingResolver(registry, HomeAssistantEntityProbe(hass)),
+    )
+
+
+def _rebind(registry: BindHomeRegistry, logical: BindHomeLight, entity_id: str) -> None:
+    registry.set_binding(
+        Binding.create(
+            asset_id=logical.asset_id,
+            capability="on_off",
+            entity_id=entity_id,
+        )
+    )
+
+
+async def test_on_off_backing_light_advertises_only_on_off(
+    hass: HomeAssistant,
+) -> None:
+    registry = BindHomeRegistry()
+    hass.states.async_set(
+        "light.onoff",
+        "off",
+        {
+            "supported_color_modes": [ColorMode.ONOFF],
+            "color_mode": ColorMode.ONOFF,
+            "supported_features": 0,
+        },
+    )
+    logical = _setup(registry, hass, "light.onoff")
+
+    await logical.async_update()
+
+    assert logical.available is True
+    assert logical.supported_color_modes == {ColorMode.ONOFF}
+    assert logical.color_mode is ColorMode.ONOFF
+    assert logical.supported_features == 0
+    assert logical.brightness is None
+
+
+async def test_dimmable_backing_light_forwards_brightness_and_transition(
+    hass: HomeAssistant,
+) -> None:
+    registry = BindHomeRegistry()
+    hass.states.async_set(
+        "light.dimmer",
+        "on",
+        {
+            "supported_color_modes": [ColorMode.BRIGHTNESS],
+            "color_mode": ColorMode.BRIGHTNESS,
+            "brightness": 96,
+            "supported_features": int(LightEntityFeature.TRANSITION),
+        },
+    )
+    logical = _setup(registry, hass, "light.dimmer")
+    calls: list[ServiceCall] = []
+
+    async def capture(call: ServiceCall) -> None:
+        calls.append(call)
+
+    hass.services.async_register("light", "turn_on", capture)
+
+    await logical.async_update()
+    await logical.async_turn_on(brightness=200, transition=1.5)
+
+    assert logical.supported_color_modes == {ColorMode.BRIGHTNESS}
+    assert logical.color_mode is ColorMode.BRIGHTNESS
+    assert logical.brightness == 96
+    assert logical.supported_features == LightEntityFeature.TRANSITION
+    assert len(calls) == 1
+    assert calls[0].domain == "light"
+    assert calls[0].service == "turn_on"
+    assert calls[0].data == {
+        "entity_id": "light.dimmer",
+        "brightness": 200,
+        "transition": 1.5,
+    }
+
+
+async def test_color_backing_light_projects_color_and_effect_metadata(
+    hass: HomeAssistant,
+) -> None:
+    registry = BindHomeRegistry()
+    hass.states.async_set(
+        "light.color",
+        "on",
+        {
+            "supported_color_modes": [ColorMode.HS, ColorMode.COLOR_TEMP],
+            "color_mode": ColorMode.HS,
+            "brightness": 180,
+            "hs_color": (220.0, 65.0),
+            "color_temp_kelvin": 3200,
+            "min_color_temp_kelvin": 2000,
+            "max_color_temp_kelvin": 6500,
+            "supported_features": int(
+                LightEntityFeature.EFFECT | LightEntityFeature.TRANSITION
+            ),
+            "effect": "relax",
+            "effect_list": ["relax", "focus"],
+        },
+    )
+    logical = _setup(registry, hass, "light.color")
+
+    await logical.async_update()
+
+    assert logical.supported_color_modes == {ColorMode.HS, ColorMode.COLOR_TEMP}
+    assert logical.color_mode is ColorMode.HS
+    assert logical.brightness == 180
+    assert logical.hs_color == (220.0, 65.0)
+    assert logical.color_temp_kelvin == 3200
+    assert logical.min_color_temp_kelvin == 2000
+    assert logical.max_color_temp_kelvin == 6500
+    assert LightEntityFeature.EFFECT in logical.supported_features
+    assert LightEntityFeature.TRANSITION in logical.supported_features
+    assert logical.effect == "relax"
+    assert logical.effect_list == ["relax", "focus"]
+
+
+async def test_rebinding_refreshes_capabilities_without_changing_logical_identity(
+    hass: HomeAssistant,
+) -> None:
+    registry = BindHomeRegistry()
+    hass.states.async_set(
+        "light.first",
+        "on",
+        {
+            "supported_color_modes": [ColorMode.BRIGHTNESS],
+            "color_mode": ColorMode.BRIGHTNESS,
+            "brightness": 120,
+        },
+    )
+    hass.states.async_set(
+        "light.second",
+        "on",
+        {
+            "supported_color_modes": [ColorMode.RGB],
+            "color_mode": ColorMode.RGB,
+            "rgb_color": (10, 20, 30),
+        },
+    )
+    logical = _setup(registry, hass, "light.first")
+    unique_id = logical.unique_id
+
+    await logical.async_update()
+    assert logical.supported_color_modes == {ColorMode.BRIGHTNESS}
+    assert logical.brightness == 120
+
+    _rebind(registry, logical, "light.second")
+    logical.refresh_binding_subscription()
+
+    assert logical.unique_id == unique_id
+    assert logical.supported_color_modes == {ColorMode.RGB}
+    assert logical.color_mode is ColorMode.RGB
+    assert logical.rgb_color == (10, 20, 30)
+    assert logical.brightness is None
+
+
+@pytest.mark.parametrize("state", ["unavailable", "unknown"])
+async def test_command_fails_visibly_when_backing_light_is_not_available(
+    hass: HomeAssistant,
+    state: str,
+) -> None:
+    registry = BindHomeRegistry()
+    hass.states.async_set(
+        "light.offline",
+        state,
+        {
+            "supported_color_modes": [ColorMode.BRIGHTNESS],
+            "color_mode": ColorMode.BRIGHTNESS,
+        },
+    )
+    logical = _setup(registry, hass, "light.offline")
+    calls: list[ServiceCall] = []
+
+    async def capture(call: ServiceCall) -> None:
+        calls.append(call)
+
+    hass.services.async_register("light", "turn_on", capture)
+
+    with pytest.raises(HomeAssistantError, match="runtime_(unavailable|unknown)"):
+        await logical.async_turn_on(brightness=200)
+
+    assert calls == []

--- a/tests/test_light_capability_proxy.py
+++ b/tests/test_light_capability_proxy.py
@@ -8,7 +8,10 @@ from homeassistant.exceptions import HomeAssistantError
 from custom_components.bindhome.light import BindHomeLight
 from custom_components.bindhome.models import Asset, Binding
 from custom_components.bindhome.registry import BindHomeRegistry
-from custom_components.bindhome.resolver import BindingResolver, HomeAssistantEntityProbe
+from custom_components.bindhome.resolver import (
+    BindingResolver,
+    HomeAssistantEntityProbe,
+)
 
 
 def _setup(

--- a/tests/test_light_capability_proxy.py
+++ b/tests/test_light_capability_proxy.py
@@ -11,7 +11,11 @@ from custom_components.bindhome.registry import BindHomeRegistry
 from custom_components.bindhome.resolver import BindingResolver, HomeAssistantEntityProbe
 
 
-def _setup(registry: BindHomeRegistry, hass: HomeAssistant, entity_id: str) -> BindHomeLight:
+def _setup(
+    registry: BindHomeRegistry,
+    hass: HomeAssistant,
+    entity_id: str,
+) -> BindHomeLight:
     asset = registry.add_asset(
         Asset.create(
             name="Proxy light",
@@ -139,8 +143,8 @@ async def test_color_backing_light_projects_color_and_effect_metadata(
     assert logical.color_temp_kelvin == 3200
     assert logical.min_color_temp_kelvin == 2000
     assert logical.max_color_temp_kelvin == 6500
-    assert LightEntityFeature.EFFECT in logical.supported_features
-    assert LightEntityFeature.TRANSITION in logical.supported_features
+    assert logical.supported_features & LightEntityFeature.EFFECT
+    assert logical.supported_features & LightEntityFeature.TRANSITION
     assert logical.effect == "relax"
     assert logical.effect_list == ["relax", "focus"]
 


### PR DESCRIPTION
## Summary

Closes #30 by making BindHome logical `light` Representations faithfully proxy the capabilities of their current Home Assistant backing light while preserving stable BindHome identity.

- Backing `light.*` entities now drive the logical light's advertised `supported_color_modes`, current color mode, brightness/color metadata, color-temperature range and supported transition/effect/flash features.
- `turn_on` / `turn_off` forward light service kwargs such as brightness, color, effect and transition to Home Assistant's `light` service when the resolved target is a light.
- Non-light backing targets remain deliberately ON/OFF-only and continue through Home Assistant's generic turn routing, avoiding a parallel domain compatibility catalogue.
- Rebinding recalculates advertised capabilities immediately without changing the logical entity `unique_id`.
- Missing, stale, unavailable or unknown backing targets now raise `HomeAssistantError` instead of silently accepting a command as a no-op.
- Product contract and changelog document which metadata/capabilities are owned by BindHome versus proxied from Home Assistant.

## Tests

Adds explicit coverage for:

- ON/OFF-only backing lights;
- dimmable lights and brightness/transition forwarding;
- color-capable lights including effect metadata;
- rebinding between lights with different capabilities while preserving logical identity;
- unavailable/unknown backing lights failing visibly;
- existing generic non-light delegation;
- missing Binding failure replacing the old silent-no-op behavior.

## Scope

No Registry schema, Binding persistence, frontend bundle or Representation identity changes are included.

Closes #30.