### PR TITLE
feat: define logical entity metadata ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 
 ## [Unreleased]
 
+### Changed
+
+- Logical Representation metadata ownership is now explicit: BindHome keeps the integration-provided original name and physical Area aligned with the Asset while preserving Home Assistant user overrides such as the custom entity name, `entity_id` and icon across reconciliation and restart. ([#44](https://github.com/alessbarb/bindhome/issues/44))
+
 ---
 
 ## [1.3.0] - 2026-09-06

--- a/custom_components/bindhome/light.py
+++ b/custom_components/bindhome/light.py
@@ -42,6 +42,19 @@ def _entity_registry_id(asset_id: str) -> tuple[str, str, str]:
     return contract.domain, DOMAIN, contract.unique_id
 
 
+def _sync_owned_entity_registry_metadata(
+    entity_registry: er.EntityRegistry,
+    entity_id: str,
+    asset: Asset,
+) -> None:
+    """Synchronize only logical-entity metadata owned by BindHome."""
+    entity_registry.async_update_entity(
+        entity_id,
+        area_id=asset.area_id,
+        original_name=asset.name,
+    )
+
+
 def _color_mode(value: Any) -> ColorMode | None:
     """Coerce one Home Assistant state attribute to a known color mode."""
     try:
@@ -134,10 +147,10 @@ async def async_setup_entry(
                     *_entity_registry_id(asset_id)
                 )
                 if entity_id is not None:
-                    entity_registry.async_update_entity(
+                    _sync_owned_entity_registry_metadata(
+                        entity_registry,
                         entity_id,
-                        area_id=asset.area_id,
-                        original_name=asset.name,
+                        asset,
                     )
 
             # Add newly eligible assets.
@@ -196,6 +209,12 @@ class BindHomeLight(LightEntity):
     async def async_added_to_hass(self) -> None:
         """Subscribe to the currently resolved backing entity."""
         await super().async_added_to_hass()
+        if self.entity_id is not None:
+            _sync_owned_entity_registry_metadata(
+                er.async_get(self.hass),
+                self.entity_id,
+                self._asset,
+            )
         self.refresh_binding_subscription()
         self._unsub_binding_target = async_dispatcher_connect(
             self.hass,

--- a/custom_components/bindhome/translations/en.json
+++ b/custom_components/bindhome/translations/en.json
@@ -318,7 +318,7 @@
     "panel_editor_edit": "Edit",
     "panel_editor_details": "Asset details",
     "panel_editor_edit_title": "Edit Asset",
-    "panel_editor_identity_note": "Saving changes preserves this Asset's stable identity.",
+    "panel_editor_identity_note": "Saving preserves this Asset's stable identity. If it has a logical Representation, its original name and Home Assistant Area follow the Asset; Home Assistant custom name, entity ID and icon remain user-controlled.",
     "panel_editor_unknown_area_option": "Unknown Area — {area_id}",
     "panel_editor_cancel": "Cancel",
     "panel_editor_save": "Save changes",

--- a/custom_components/bindhome/translations/es.json
+++ b/custom_components/bindhome/translations/es.json
@@ -318,7 +318,7 @@
     "panel_editor_edit": "Editar",
     "panel_editor_details": "Detalles del elemento",
     "panel_editor_edit_title": "Editar elemento",
-    "panel_editor_identity_note": "Guardar los cambios conserva la identidad estable de este elemento.",
+    "panel_editor_identity_note": "Guardar conserva la identidad estable de este elemento. Si tiene una representación lógica, su nombre original y su Área de Home Assistant se actualizan desde el elemento; el nombre personalizado, el ID de entidad y el icono configurados en Home Assistant siguen bajo control del usuario.",
     "panel_editor_unknown_area_option": "Área desconocida — {area_id}",
     "panel_editor_cancel": "Cancelar",
     "panel_editor_save": "Guardar cambios",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,10 @@ Representation requirements describe BindHome's own implementation contract; the
 
 Removing a Representation removes the logical entity while preserving the physical Asset. Re-adding it restores the same stable logical identity derived from the Asset.
 
+Representation reconciliation deliberately separates integration-owned metadata from Home Assistant user customization. BindHome synchronizes the Entity Registry `original_name` from the Asset name and `area_id` from the Asset location. The custom Entity Registry `name`, user-selected `entity_id`, icon, aliases, labels and user disabled/hidden choices remain Home Assistant-owned and are not reset by BindHome reconciliation. A direct Area override on the logical entity is not durable because the Asset remains the physical location source of truth; moving the Asset is the supported way to move its Representation.
+
+The current `light` platform applies that ownership policy both when the entity first enters Home Assistant and on later Registry reconciliation. Future Representation platforms must reuse the same policy rather than inventing platform-specific metadata ownership.
+
 ### Creation preset
 
 Creation presets are read-only UX metadata used to generate editable Asset drafts during inventory.
@@ -290,7 +294,7 @@ The panel reads Home Assistant Floors, Areas, Entity Registry and Device Registr
 
 Room inventory uses Home Assistant Areas as location references and BindHome presets to generate editable local drafts. Accepted batches are persisted with one transactional `bindhome/assets/create_bulk` request.
 
-Human editing preserves stable Asset identity. Hardware connection uses replacement-safe Binding operations rather than delete-before-set sequences. Normal connection UI displays the resolver's current Home Assistant `entity_id`; the stable Registry target identity remains an implementation detail available to technical/Advanced inspection.
+Human editing preserves stable Asset identity. When an Asset has a logical Representation, Asset name/Area edits update only the integration-owned original name and area of that logical entity; Home Assistant user custom name, `entity_id` and icon are preserved. Hardware connection uses replacement-safe Binding operations rather than delete-before-set sequences. Normal connection UI displays the resolver's current Home Assistant `entity_id`; the stable Registry target identity remains an implementation detail available to technical/Advanced inspection.
 
 Topology uses the same directed Relation objects as the backend and supports bounded search/navigation.
 

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -101,6 +101,29 @@ The current BindHome 1.x contract supports zero or one Representation per Asset.
 
 Removing a Representation removes the logical entity while preserving the Asset. Re-adding the same Representation preserves the stable logical identity derived from the Asset.
 
+#### Logical entity metadata ownership
+
+A logical Representation spans two ownership domains: BindHome supplies the integration-owned defaults that describe the physical Asset, while Home Assistant retains the normal Entity Registry customization surface for the user.
+
+BindHome owns and reconciles:
+
+- the Representation's stable `unique_id` and platform identity;
+- Entity Registry `original_name`, derived from the current Asset name;
+- Entity Registry `area_id`, derived from the current Asset Area because BindHome's physical inventory is authoritative for the Asset's location;
+- runtime state, availability and integration-provided capabilities according to the Representation platform contract.
+
+Home Assistant user customization owns and BindHome must preserve:
+
+- the Entity Registry custom `name`;
+- the user-selected `entity_id`;
+- the custom icon;
+- aliases and labels;
+- user disabled/hidden choices and other user-owned Entity Registry settings that BindHome does not explicitly own.
+
+A Home Assistant custom name therefore remains in force even when the Asset is renamed; BindHome updates only `original_name`. A user-selected `entity_id` or icon also survives reconciliation and restart because stable Representation identity does not depend on either field.
+
+Area is intentionally different. The Asset's `area_id` is the physical location source of truth, so a direct Area reassignment of the logical entity in Home Assistant is not durable: the next BindHome reconciliation restores the Representation to the Asset Area. To move the logical Representation permanently, move the Asset in BindHome; that Area change propagates to the Representation without changing its identity.
+
 ## Normal user workflow
 
 The intended lifecycle is progressive:
@@ -177,6 +200,8 @@ Human editing may change:
 - supported human-editable metadata.
 
 It must preserve the Asset ID.
+
+If the Asset has a logical Representation, changing its name updates the Representation's integration-provided original name and changing its Area moves the Representation to that Area. Home Assistant custom entity name, `entity_id` and icon remain user-owned and are not reset by those Asset edits.
 
 A failed save keeps the draft available for correction. A successful write remains committed even if a subsequent refresh fails; the UI should report synchronization uncertainty rather than repeat the mutation.
 
@@ -296,7 +321,7 @@ Replacing hardware should not require changing automations that target the stabl
 
 Renaming the currently bound registered Home Assistant entity also must not require changing the BindHome logical entity or Binding. Logical runtime consumers follow the stable Binding target to its current `entity_id`.
 
-A logical `light` owns its stable BindHome identity, name/location metadata and the fact that it is exposed as a Light. It does not invent hardware light features. When its resolved backing target is another Home Assistant `light`, BindHome mirrors the backing light's currently advertised color modes, brightness/color state and supported Light features such as transition/effect, and forwards supported `turn_on`/`turn_off` service parameters through Home Assistant. Rebinding recalculates those advertised capabilities without changing the logical entity identity.
+A logical `light` owns its stable BindHome identity, integration-provided original name/location metadata and the fact that it is exposed as a Light, while preserving Home Assistant user overrides according to the metadata ownership contract above. It does not invent hardware light features. When its resolved backing target is another Home Assistant `light`, BindHome mirrors the backing light's currently advertised color modes, brightness/color state and supported Light features such as transition/effect, and forwards supported `turn_on`/`turn_off` service parameters through Home Assistant. Rebinding recalculates those advertised capabilities without changing the logical entity identity.
 
 When the resolved target is not a Home Assistant `light`, the logical Representation exposes only safe ON/OFF semantics and delegates generic turn services to Home Assistant. BindHome does not maintain a parallel cross-domain compatibility catalogue or emulate brightness/color capabilities that the backing entity does not provide.
 

--- a/tests/test_light_reconciliation.py
+++ b/tests/test_light_reconciliation.py
@@ -2,6 +2,7 @@
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -81,6 +82,40 @@ async def test_setting_light_representation_adds_logical_light_dynamically(
 
     assert entity_id is not None
     assert hass.states.get(entity_id) is not None
+
+
+async def test_new_logical_light_receives_bindhome_owned_metadata_immediately(
+    hass: HomeAssistant,
+    bindhome_entry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+    area = ar.async_get(hass).async_create("Living room")
+
+    asset = await manager.async_create_asset(
+        name="Living room ceiling light",
+        asset_type="light_point",
+        code=None,
+        area_id=area.id,
+        capabilities=["on_off"],
+    )
+    await manager.async_set_representation(
+        asset_id=asset.id,
+        platform="light",
+    )
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        f"{DOMAIN}_{asset.id}",
+    )
+    assert entity_id is not None
+
+    registry_entry = registry.async_get(entity_id)
+    assert registry_entry is not None
+    assert registry_entry.original_name == asset.name
+    assert registry_entry.area_id == area.id
 
 
 async def test_adding_on_off_capability_alone_does_not_infer_light(
@@ -176,6 +211,130 @@ async def test_logical_light_metadata_updates_without_identity_change(
     registry_entry = registry.async_get(entity_id)
     assert registry_entry is not None
     assert registry_entry.original_name == "New name"
+
+
+async def test_logical_light_preserves_home_assistant_user_overrides(
+    hass: HomeAssistant,
+    bindhome_entry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+    area = ar.async_get(hass).async_create("Living room")
+
+    asset = await manager.async_create_asset(
+        name="Ceiling light",
+        asset_type="light_point",
+        code=None,
+        area_id=area.id,
+        capabilities=["on_off"],
+    )
+    await manager.async_set_representation(
+        asset_id=asset.id,
+        platform="light",
+    )
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    unique_id = f"{DOMAIN}_{asset.id}"
+    entity_id = registry.async_get_entity_id("light", DOMAIN, unique_id)
+    assert entity_id is not None
+
+    custom_entity_id = "light.my_ceiling_light"
+    registry.async_update_entity(
+        entity_id,
+        name="My ceiling light",
+        icon="mdi:star",
+        new_entity_id=custom_entity_id,
+    )
+    await hass.async_block_till_done()
+
+    await manager.async_update_asset(
+        asset_id=asset.id,
+        name="Renamed physical light",
+        asset_type=asset.asset_type,
+        code="LGT-01",
+        area_id=asset.area_id,
+        capabilities=list(asset.capabilities),
+    )
+    await hass.async_block_till_done()
+
+    assert registry.async_get_entity_id("light", DOMAIN, unique_id) == custom_entity_id
+    registry_entry = registry.async_get(custom_entity_id)
+    assert registry_entry is not None
+    assert registry_entry.name == "My ceiling light"
+    assert registry_entry.icon == "mdi:star"
+    assert registry_entry.original_name == "Renamed physical light"
+    assert registry_entry.area_id == area.id
+
+    assert await hass.config_entries.async_unload(bindhome_entry.entry_id)
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(bindhome_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert registry.async_get_entity_id("light", DOMAIN, unique_id) == custom_entity_id
+    registry_entry = registry.async_get(custom_entity_id)
+    assert registry_entry is not None
+    assert registry_entry.name == "My ceiling light"
+    assert registry_entry.icon == "mdi:star"
+    assert registry_entry.original_name == "Renamed physical light"
+    assert registry_entry.area_id == area.id
+
+
+async def test_logical_light_area_follows_asset_not_entity_override(
+    hass: HomeAssistant,
+    bindhome_entry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+    asset_area = ar.async_get(hass).async_create("Living room")
+    override_area = ar.async_get(hass).async_create("Kitchen")
+    moved_area = ar.async_get(hass).async_create("Dining room")
+
+    asset = await manager.async_create_asset(
+        name="Ceiling light",
+        asset_type="light_point",
+        code=None,
+        area_id=asset_area.id,
+        capabilities=["on_off"],
+    )
+    await manager.async_set_representation(
+        asset_id=asset.id,
+        platform="light",
+    )
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        f"{DOMAIN}_{asset.id}",
+    )
+    assert entity_id is not None
+
+    registry.async_update_entity(entity_id, area_id=override_area.id)
+    assert registry.async_get(entity_id).area_id == override_area.id
+
+    await manager.async_update_asset(
+        asset_id=asset.id,
+        name=asset.name,
+        asset_type=asset.asset_type,
+        code="LGT-AREA",
+        area_id=asset.area_id,
+        capabilities=list(asset.capabilities),
+    )
+    await hass.async_block_till_done()
+
+    assert registry.async_get(entity_id).area_id == asset_area.id
+
+    await manager.async_update_asset(
+        asset_id=asset.id,
+        name=asset.name,
+        asset_type=asset.asset_type,
+        code="LGT-MOVED",
+        area_id=moved_area.id,
+        capabilities=list(asset.capabilities),
+    )
+    await hass.async_block_till_done()
+
+    assert registry.async_get(entity_id).area_id == moved_area.id
 
 
 async def test_removing_representation_removes_logical_light_but_keeps_asset(


### PR DESCRIPTION
## Summary

- define the ownership contract for logical Representation metadata;
- keep BindHome-owned `original_name` and physical `area_id` aligned with the Asset on initial entity creation and later reconciliation;
- preserve Home Assistant user overrides such as custom name, `entity_id` and icon across Asset updates and config-entry reloads;
- document that a direct logical-entity Area override is not durable because the Asset remains the physical location source of truth;
- surface the policy in the existing Asset editor notice in English and Spanish;
- add the user-visible change to `CHANGELOG.md` under Unreleased.

## Tests

Adds reconciliation coverage for:

- owned metadata applied immediately when a logical light is created;
- custom Home Assistant name / entity ID / icon surviving Asset changes and integration reload;
- logical entity Area returning to the Asset Area after a direct Home Assistant override and following a later Asset move.

No Registry schema change or migration is introduced.

Closes #44.