### PR TITLE
feat: define assisted import proposal contract

### DIFF
--- a/custom_components/bindhome/import_proposals.py
+++ b/custom_components/bindhome/import_proposals.py
@@ -1,0 +1,420 @@
+"""Pure proposal contract for assisted Home Assistant inventory import."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+from hashlib import sha256
+
+from .models import (
+    Asset,
+    Binding,
+    normalize_identifier,
+    normalize_non_empty,
+)
+
+
+class ImportDuplicateStatus(StrEnum):
+    """How confidently an import proposal overlaps existing BindHome state."""
+
+    NEW = "new"
+    ALREADY_BOUND = "already_bound"
+    POSSIBLE_ASSET_MATCH = "possible_asset_match"
+    AMBIGUOUS = "ambiguous"
+
+
+class ImportDecisionAction(StrEnum):
+    """Explicit user outcome for one reviewed import proposal."""
+
+    CREATE = "create"
+    MERGE = "merge"
+    SKIP = "skip"
+
+
+@dataclass(frozen=True, slots=True)
+class ImportSource:
+    """Traceable Home Assistant identities that produced one proposal."""
+
+    area_id: str | None
+    device_id: str | None
+    entity_ids: tuple[str, ...]
+    entity_registry_ids: tuple[str, ...]
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        area_id: str | None = None,
+        device_id: str | None = None,
+        entity_ids: Iterable[str] = (),
+        entity_registry_ids: Iterable[str] = (),
+    ) -> ImportSource:
+        """Create a deterministic, normalized source descriptor."""
+        normalized_entity_ids = tuple(
+            sorted({normalize_non_empty(value, "entity_id") for value in entity_ids})
+        )
+        normalized_registry_ids = tuple(
+            sorted(
+                {
+                    normalize_non_empty(value, "entity_registry_id")
+                    for value in entity_registry_ids
+                }
+            )
+        )
+        normalized_device_id = (
+            normalize_non_empty(device_id, "device_id")
+            if device_id is not None
+            else None
+        )
+        if normalized_device_id is None and not normalized_entity_ids:
+            raise ValueError("Import source requires a Device or at least one Entity")
+
+        return cls(
+            area_id=(
+                normalize_non_empty(area_id, "area_id") if area_id is not None else None
+            ),
+            device_id=normalized_device_id,
+            entity_ids=normalized_entity_ids,
+            entity_registry_ids=normalized_registry_ids,
+        )
+
+    def fingerprint(self) -> str:
+        """Return stable source identity independent from mutable display metadata."""
+        parts: list[str] = []
+        if self.device_id is not None:
+            parts.append(f"device:{self.device_id}")
+        if self.entity_registry_ids:
+            parts.extend(f"registry:{value}" for value in self.entity_registry_ids)
+        else:
+            parts.extend(f"entity:{value}" for value in self.entity_ids)
+        return "|".join(parts)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize source traceability for API/UI consumers."""
+        return {
+            "area_id": self.area_id,
+            "device_id": self.device_id,
+            "entity_ids": list(self.entity_ids),
+            "entity_registry_ids": list(self.entity_registry_ids),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ImportAssetCandidate:
+    """Editable Asset data proposed from Home Assistant metadata."""
+
+    name: str
+    asset_type: str
+    area_id: str | None
+    capabilities: tuple[str, ...]
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        name: str,
+        asset_type: str,
+        area_id: str | None = None,
+        capabilities: Iterable[str] = (),
+    ) -> ImportAssetCandidate:
+        """Create normalized editable Asset candidate data."""
+        return cls(
+            name=normalize_non_empty(name, "name"),
+            asset_type=normalize_identifier(asset_type, "asset_type"),
+            area_id=(
+                normalize_non_empty(area_id, "area_id") if area_id is not None else None
+            ),
+            capabilities=tuple(
+                sorted(
+                    {
+                        normalize_identifier(capability, "capability")
+                        for capability in capabilities
+                    }
+                )
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize candidate data for review clients."""
+        return {
+            "name": self.name,
+            "asset_type": self.asset_type,
+            "area_id": self.area_id,
+            "capabilities": list(self.capabilities),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ImportBindingCandidate:
+    """One proposed capability Binding to an existing Home Assistant entity."""
+
+    capability: str
+    role: str
+    entity_id: str
+    entity_registry_id: str | None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        capability: str,
+        entity_id: str,
+        entity_registry_id: str | None = None,
+        role: str = "primary",
+    ) -> ImportBindingCandidate:
+        """Create one normalized Binding candidate."""
+        return cls(
+            capability=normalize_identifier(capability, "capability"),
+            role=normalize_identifier(role, "role"),
+            entity_id=normalize_non_empty(entity_id, "entity_id"),
+            entity_registry_id=(
+                normalize_non_empty(entity_registry_id, "entity_registry_id")
+                if entity_registry_id is not None
+                else None
+            ),
+        )
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Serialize Binding candidate data."""
+        return {
+            "capability": self.capability,
+            "role": self.role,
+            "entity_id": self.entity_id,
+            "entity_registry_id": self.entity_registry_id,
+        }
+
+
+def _matches_existing_binding(
+    candidate: ImportBindingCandidate,
+    binding: Binding,
+) -> bool:
+    """Return whether candidate and persisted Binding identify the same target."""
+    if candidate.entity_registry_id is not None:
+        return candidate.entity_registry_id == binding.entity_registry_id
+    return (
+        binding.entity_registry_id is None and candidate.entity_id == binding.entity_id
+    )
+
+
+def analyze_import_duplicate(
+    *,
+    asset: ImportAssetCandidate,
+    bindings: Iterable[ImportBindingCandidate],
+    existing_assets: Iterable[Asset],
+    existing_bindings: Iterable[Binding],
+) -> tuple[ImportDuplicateStatus, tuple[str, ...]]:
+    """Classify duplicate evidence without making an automatic merge decision.
+
+    Stable Binding target identity is definitive. Asset display metadata is only
+    advisory: exact name/type/Area matches are surfaced as possible merge targets
+    and never silently treated as the same physical Asset.
+    """
+    binding_candidates = tuple(bindings)
+    persisted_bindings = tuple(existing_bindings)
+    bound_asset_ids = tuple(
+        sorted(
+            {
+                binding.asset_id
+                for binding in persisted_bindings
+                for candidate in binding_candidates
+                if _matches_existing_binding(candidate, binding)
+            }
+        )
+    )
+    if bound_asset_ids:
+        return ImportDuplicateStatus.ALREADY_BOUND, bound_asset_ids
+
+    candidate_name = asset.name.casefold()
+    metadata_matches = tuple(
+        sorted(
+            current.id
+            for current in existing_assets
+            if current.name.casefold() == candidate_name
+            and current.asset_type == asset.asset_type
+            and current.area_id == asset.area_id
+        )
+    )
+    if len(metadata_matches) == 1:
+        return ImportDuplicateStatus.POSSIBLE_ASSET_MATCH, metadata_matches
+    if len(metadata_matches) > 1:
+        return ImportDuplicateStatus.AMBIGUOUS, metadata_matches
+    return ImportDuplicateStatus.NEW, ()
+
+
+def _proposal_id(source: ImportSource, candidate_key: str) -> str:
+    """Derive a deterministic workflow identity from stable HA source identity."""
+    key = normalize_non_empty(candidate_key, "candidate_key")
+    digest = sha256(f"{source.fingerprint()}|candidate:{key}".encode()).hexdigest()
+    return f"ha_{digest[:24]}"
+
+
+@dataclass(frozen=True, slots=True)
+class ImportProposal:
+    """One non-mutating assisted-import proposal awaiting user review."""
+
+    proposal_id: str
+    source: ImportSource
+    asset: ImportAssetCandidate
+    bindings: tuple[ImportBindingCandidate, ...]
+    duplicate_status: ImportDuplicateStatus
+    merge_candidate_asset_ids: tuple[str, ...]
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        source: ImportSource,
+        asset: ImportAssetCandidate,
+        bindings: Iterable[ImportBindingCandidate],
+        existing_assets: Iterable[Asset] = (),
+        existing_bindings: Iterable[Binding] = (),
+        candidate_key: str = "default",
+    ) -> ImportProposal:
+        """Build a proposal and deterministic duplicate analysis."""
+        normalized_bindings = tuple(bindings)
+        missing_capabilities = {
+            binding.capability for binding in normalized_bindings
+        } - set(asset.capabilities)
+        if missing_capabilities:
+            missing = ", ".join(sorted(missing_capabilities))
+            raise ValueError(
+                f"Binding candidates require undeclared capabilities: {missing}"
+            )
+
+        duplicate_status, merge_candidates = analyze_import_duplicate(
+            asset=asset,
+            bindings=normalized_bindings,
+            existing_assets=existing_assets,
+            existing_bindings=existing_bindings,
+        )
+        return cls(
+            proposal_id=_proposal_id(source, candidate_key),
+            source=source,
+            asset=asset,
+            bindings=normalized_bindings,
+            duplicate_status=duplicate_status,
+            merge_candidate_asset_ids=merge_candidates,
+        )
+
+    @property
+    def requires_review(self) -> bool:
+        """Return whether a human decision is required before commit."""
+        return True
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize proposal data for a review surface."""
+        return {
+            "proposal_id": self.proposal_id,
+            "source": self.source.to_dict(),
+            "asset": self.asset.to_dict(),
+            "bindings": [binding.to_dict() for binding in self.bindings],
+            "duplicate_status": self.duplicate_status.value,
+            "merge_candidate_asset_ids": list(self.merge_candidate_asset_ids),
+            "requires_review": True,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ImportDecision:
+    """Explicit user-reviewed outcome for one proposal."""
+
+    action: ImportDecisionAction
+    asset: ImportAssetCandidate | None = None
+    target_asset_id: str | None = None
+    bindings: tuple[ImportBindingCandidate, ...] | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        action: ImportDecisionAction | str,
+        asset: ImportAssetCandidate | None = None,
+        target_asset_id: str | None = None,
+        bindings: Iterable[ImportBindingCandidate] | None = None,
+    ) -> ImportDecision:
+        """Create and validate an explicit create/merge/skip decision."""
+        normalized_action = ImportDecisionAction(action)
+        normalized_target = (
+            normalize_non_empty(target_asset_id, "target_asset_id")
+            if target_asset_id is not None
+            else None
+        )
+        normalized_bindings = tuple(bindings) if bindings is not None else None
+
+        if normalized_action is ImportDecisionAction.CREATE:
+            if asset is None or normalized_target is not None:
+                raise ValueError(
+                    "Create decision requires Asset data and no merge target"
+                )
+        elif normalized_action is ImportDecisionAction.MERGE:
+            if normalized_target is None or asset is not None:
+                raise ValueError(
+                    "Merge decision requires target_asset_id and no new Asset"
+                )
+        elif (
+            asset is not None
+            or normalized_target is not None
+            or normalized_bindings is not None
+        ):
+            raise ValueError("Skip decision cannot carry Asset, target or Binding data")
+
+        if asset is not None and normalized_bindings is not None:
+            missing_capabilities = {
+                binding.capability for binding in normalized_bindings
+            } - set(asset.capabilities)
+            if missing_capabilities:
+                missing = ", ".join(sorted(missing_capabilities))
+                raise ValueError(
+                    f"Accepted Bindings require undeclared capabilities: {missing}"
+                )
+
+        return cls(
+            action=normalized_action,
+            asset=asset,
+            target_asset_id=normalized_target,
+            bindings=normalized_bindings,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptedImport:
+    """Commit-ready result of applying one explicit decision to a proposal."""
+
+    proposal_id: str
+    source: ImportSource
+    action: ImportDecisionAction
+    asset: ImportAssetCandidate | None
+    target_asset_id: str | None
+    bindings: tuple[ImportBindingCandidate, ...]
+
+
+def apply_import_decision(
+    proposal: ImportProposal,
+    decision: ImportDecision,
+) -> AcceptedImport | None:
+    """Materialize reviewed data without mutating BindHome or Home Assistant."""
+    if decision.action is ImportDecisionAction.SKIP:
+        return None
+
+    bindings = proposal.bindings if decision.bindings is None else decision.bindings
+    asset = decision.asset
+
+    if asset is not None:
+        missing_capabilities = {binding.capability for binding in bindings} - set(
+            asset.capabilities
+        )
+        if missing_capabilities:
+            missing = ", ".join(sorted(missing_capabilities))
+            raise ValueError(
+                f"Accepted Bindings require undeclared capabilities: {missing}"
+            )
+
+    return AcceptedImport(
+        proposal_id=proposal.proposal_id,
+        source=proposal.source,
+        action=decision.action,
+        asset=asset,
+        target_asset_id=decision.target_asset_id,
+        bindings=bindings,
+    )

--- a/docs/assisted-import.md
+++ b/docs/assisted-import.md
@@ -1,0 +1,121 @@
+# Assisted import proposal contract
+
+BindHome assisted import is a review workflow over Home Assistant metadata. It is deliberately split into discovery, proposal review and transactional commit so that Home Assistant data is never mutated and no inferred physical model is committed silently.
+
+This document defines the intermediate proposal contract shared by backend discovery, frontend review and the final commit step.
+
+## Principles
+
+1. Discovery is read-only. It may inspect Home Assistant Areas, Devices and Entities but does not write BindHome or Home Assistant state.
+2. Every proposal remains a suggestion until a user explicitly chooses create, merge or skip.
+3. Stable Home Assistant Entity Registry identity is preferred when available. Mutable `entity_id` is used only as the explicit fallback for state-machine-only entities.
+4. Display metadata is not physical identity. Matching name, type and Area may suggest an existing Asset but never authorizes an automatic merge.
+5. The accepted proposal set is materialized into commit-ready data first, then committed through one BindHome transaction.
+6. The workflow can be rerun safely. Already-bound stable entities are recognized deterministically.
+
+## Proposal model
+
+Each `ImportProposal` contains four independent concerns.
+
+### Source traceability
+
+`ImportSource` retains the Home Assistant identities that produced the proposal:
+
+- `area_id` when the source belongs to an Area;
+- `device_id` when discovery grouped entities through a Device;
+- current `entity_ids` for human-readable traceability;
+- stable Entity Registry entry IDs when those entries exist.
+
+The source descriptor is workflow metadata only. It is not persisted into the BindHome Registry schema.
+
+### Candidate Asset
+
+`ImportAssetCandidate` contains editable physical inventory data:
+
+- name;
+- `asset_type`;
+- Area reference;
+- proposed Capabilities.
+
+Discovery may derive these values from Home Assistant names, domains, device classes or other safe metadata, but they remain editable suggestions. Custom Asset types and Capabilities remain valid.
+
+### Candidate Bindings
+
+Each `ImportBindingCandidate` describes one proposed `(capability, role) -> Home Assistant entity` connection. It carries both the current `entity_id` and stable Entity Registry identity when available.
+
+A proposal may contain multiple Binding candidates when one physical Device exposes several relevant functions. The proposal Asset must declare every Capability used by its proposed Bindings.
+
+### Duplicate analysis
+
+`ImportDuplicateStatus` communicates evidence without silently deciding what the user wants:
+
+- `new`: no existing overlap found;
+- `already_bound`: at least one proposed entity target is already represented by an existing BindHome Binding;
+- `possible_asset_match`: exactly one existing Asset has the same normalized display name, type and Area, but no stable Binding identity proves it is the same physical thing;
+- `ambiguous`: multiple existing Assets match that advisory metadata.
+
+`merge_candidate_asset_ids` identifies the existing Assets relevant to the status.
+
+## Deterministic deduplication rules
+
+### Registered entities
+
+When a candidate has an Entity Registry identity, that stable ID is authoritative. An existing Binding with the same stable target makes the proposal `already_bound`, even if Home Assistant has renamed the entity since the Binding was stored.
+
+The importer must not fall back to a historical `entity_id` when a stable Registry identity exists.
+
+### State-machine-only entities
+
+When both candidate and existing Binding lack Entity Registry identity, exact `entity_id` equality is the compatibility fallback.
+
+### Existing Assets without matching Bindings
+
+An exact case-insensitive name plus `asset_type` plus Area match is only a merge suggestion. It never creates, changes or merges an Asset automatically. One match produces `possible_asset_match`; multiple matches produce `ambiguous`.
+
+This keeps physical identity a user decision rather than making display strings authoritative.
+
+### Repeat import
+
+A previously imported smart entity is normally detected on the next run because the committed Binding retains its stable Entity Registry target. The repeated proposal therefore returns `already_bound` and can be skipped or intentionally merged/reviewed without creating a duplicate Asset.
+
+## Review outcomes
+
+Every proposal requires an explicit review outcome.
+
+### Create
+
+The user accepts creation of a new Asset. The review surface submits the complete final `ImportAssetCandidate`, so rename, reclassification, Area correction and Capability editing all happen before commit. The user may also retain or remove proposed Binding candidates.
+
+### Merge
+
+The user selects an existing stable Asset ID. No new Asset is created; the accepted Binding candidates are applied to that chosen Asset during the later transactional commit step. A metadata match may be offered as a shortcut but does not select the target automatically.
+
+### Skip
+
+Nothing from that proposal enters the commit set.
+
+`apply_import_decision()` converts a reviewed proposal plus explicit decision into `AcceptedImport` data without mutating either system. A skipped proposal materializes to no commit item.
+
+## Ambiguous discovery
+
+Discovery must not force every Home Assistant Device into one BindHome Asset. If a Device/Entity grouping could sensibly represent several physical Assets, discovery should emit separate proposals or mark the candidate for human review through deterministic candidate keys. The proposal contract supports multiple Binding candidates but does not infer topology or physical composition.
+
+Examples that remain human decisions include:
+
+- a multi-channel relay controlling several independent light points;
+- a Device exposing control and measurement entities that may belong to different physical Assets;
+- entities whose Home Assistant names are too generic to identify the physical object safely.
+
+## Transaction boundary
+
+The proposal layer never calls `BindHomeManager` mutation methods. The final import implementation must first validate the complete accepted set, then create/update Assets and Bindings inside one manager transaction using the normal Registry invariants.
+
+If validation or persistence fails, no accepted proposal is partially committed.
+
+The commit step must not modify Home Assistant Areas, Devices or Entities.
+
+## API compatibility
+
+Proposal IDs are deterministic workflow identifiers derived from Home Assistant source identities plus a discovery-provided candidate key. They are not persistent infrastructure identity and must not be used as Asset IDs.
+
+The Python contract in `custom_components/bindhome/import_proposals.py` is the canonical shape for implementation work under #38. Backend discovery and frontend review should serialize that contract rather than defining parallel structures.

--- a/tests/test_import_proposals.py
+++ b/tests/test_import_proposals.py
@@ -1,0 +1,376 @@
+"""Pure contract tests for assisted-import proposals and deduplication."""
+
+import pytest
+
+from custom_components.bindhome.import_proposals import (
+    ImportAssetCandidate,
+    ImportBindingCandidate,
+    ImportDecision,
+    ImportDecisionAction,
+    ImportDuplicateStatus,
+    ImportProposal,
+    ImportSource,
+    apply_import_decision,
+)
+from custom_components.bindhome.models import Asset, Binding
+
+
+def _source(
+    *,
+    area_id: str | None = "living_room",
+    device_id: str | None = "device-1",
+    entity_ids: tuple[str, ...] = ("light.ceiling",),
+    registry_ids: tuple[str, ...] = ("registry-1",),
+) -> ImportSource:
+    return ImportSource.create(
+        area_id=area_id,
+        device_id=device_id,
+        entity_ids=entity_ids,
+        entity_registry_ids=registry_ids,
+    )
+
+
+def _asset_candidate(
+    *,
+    name: str = "Ceiling light",
+    asset_type: str = "light_point",
+    area_id: str | None = "living_room",
+    capabilities: tuple[str, ...] = ("on_off",),
+) -> ImportAssetCandidate:
+    return ImportAssetCandidate.create(
+        name=name,
+        asset_type=asset_type,
+        area_id=area_id,
+        capabilities=capabilities,
+    )
+
+
+def _binding_candidate(
+    *,
+    capability: str = "on_off",
+    entity_id: str = "light.ceiling",
+    registry_id: str | None = "registry-1",
+    role: str = "primary",
+) -> ImportBindingCandidate:
+    return ImportBindingCandidate.create(
+        capability=capability,
+        entity_id=entity_id,
+        entity_registry_id=registry_id,
+        role=role,
+    )
+
+
+def test_device_with_one_entity_produces_new_traceable_proposal() -> None:
+    proposal = ImportProposal.create(
+        source=_source(),
+        asset=_asset_candidate(),
+        bindings=[_binding_candidate()],
+    )
+
+    assert proposal.duplicate_status is ImportDuplicateStatus.NEW
+    assert proposal.merge_candidate_asset_ids == ()
+    assert proposal.requires_review is True
+    assert proposal.source.device_id == "device-1"
+    assert proposal.source.entity_ids == ("light.ceiling",)
+    assert proposal.source.entity_registry_ids == ("registry-1",)
+    assert proposal.bindings[0].entity_registry_id == "registry-1"
+    assert proposal.to_dict()["requires_review"] is True
+
+
+def test_device_with_multiple_entities_and_capabilities_stays_one_proposal() -> None:
+    source = _source(
+        entity_ids=("sensor.power", "light.ceiling", "sensor.power"),
+        registry_ids=("registry-power", "registry-light", "registry-light"),
+    )
+    asset = _asset_candidate(capabilities=("power_measurement", "on_off"))
+    bindings = (
+        _binding_candidate(),
+        _binding_candidate(
+            capability="power_measurement",
+            entity_id="sensor.power",
+            registry_id="registry-power",
+        ),
+    )
+
+    proposal = ImportProposal.create(source=source, asset=asset, bindings=bindings)
+
+    assert proposal.source.entity_ids == ("light.ceiling", "sensor.power")
+    assert proposal.source.entity_registry_ids == (
+        "registry-light",
+        "registry-power",
+    )
+    assert {binding.capability for binding in proposal.bindings} == {
+        "on_off",
+        "power_measurement",
+    }
+
+
+def test_entity_without_device_is_supported_and_has_deterministic_identity() -> None:
+    source = _source(
+        device_id=None,
+        entity_ids=("switch.garden",),
+        registry_ids=("registry-garden",),
+    )
+    asset = _asset_candidate(
+        name="Garden switch",
+        asset_type="switch",
+        area_id="garden",
+    )
+    binding = _binding_candidate(
+        entity_id="switch.garden",
+        registry_id="registry-garden",
+    )
+
+    first = ImportProposal.create(source=source, asset=asset, bindings=[binding])
+    second = ImportProposal.create(source=source, asset=asset, bindings=[binding])
+
+    assert first.proposal_id == second.proposal_id
+    assert first.proposal_id.startswith("ha_")
+
+
+def test_registered_source_identity_survives_entity_id_rename() -> None:
+    before = ImportProposal.create(
+        source=_source(entity_ids=("light.old_name",)),
+        asset=_asset_candidate(),
+        bindings=[_binding_candidate(entity_id="light.old_name")],
+    )
+    after = ImportProposal.create(
+        source=_source(entity_ids=("light.new_name",)),
+        asset=_asset_candidate(),
+        bindings=[_binding_candidate(entity_id="light.new_name")],
+    )
+
+    assert before.proposal_id == after.proposal_id
+
+
+def test_already_bound_registered_entity_is_definitive_duplicate() -> None:
+    existing_asset = Asset.create(
+        name="Existing light",
+        asset_type="light_point",
+        area_id="living_room",
+        capabilities=["on_off"],
+    )
+    existing_binding = Binding.create(
+        asset_id=existing_asset.id,
+        capability="on_off",
+        entity_id="light.old_name",
+        entity_registry_id="registry-1",
+    )
+
+    proposal = ImportProposal.create(
+        source=_source(entity_ids=("light.new_name",)),
+        asset=_asset_candidate(name="Different display name"),
+        bindings=[_binding_candidate(entity_id="light.new_name")],
+        existing_assets=[existing_asset],
+        existing_bindings=[existing_binding],
+    )
+
+    assert proposal.duplicate_status is ImportDuplicateStatus.ALREADY_BOUND
+    assert proposal.merge_candidate_asset_ids == (existing_asset.id,)
+
+
+def test_repeat_import_after_commit_is_detected_from_binding_identity() -> None:
+    imported_asset = Asset.create(
+        name="Ceiling light",
+        asset_type="light_point",
+        area_id="living_room",
+        capabilities=["on_off"],
+    )
+    imported_binding = Binding.create(
+        asset_id=imported_asset.id,
+        capability="on_off",
+        entity_id="light.ceiling",
+        entity_registry_id="registry-1",
+    )
+
+    repeated = ImportProposal.create(
+        source=_source(),
+        asset=_asset_candidate(),
+        bindings=[_binding_candidate()],
+        existing_assets=[imported_asset],
+        existing_bindings=[imported_binding],
+    )
+
+    assert repeated.duplicate_status is ImportDuplicateStatus.ALREADY_BOUND
+    assert repeated.merge_candidate_asset_ids == (imported_asset.id,)
+
+
+def test_state_only_entity_duplicate_uses_entity_id_fallback() -> None:
+    existing_asset = Asset.create(
+        name="State only switch",
+        asset_type="switch",
+        capabilities=["on_off"],
+    )
+    existing_binding = Binding.create(
+        asset_id=existing_asset.id,
+        capability="on_off",
+        entity_id="switch.state_only",
+        entity_registry_id=None,
+    )
+
+    proposal = ImportProposal.create(
+        source=_source(
+            area_id=None,
+            device_id=None,
+            entity_ids=("switch.state_only",),
+            registry_ids=(),
+        ),
+        asset=_asset_candidate(
+            name="State only switch",
+            asset_type="switch",
+            area_id=None,
+        ),
+        bindings=[
+            _binding_candidate(
+                entity_id="switch.state_only",
+                registry_id=None,
+            )
+        ],
+        existing_bindings=[existing_binding],
+    )
+
+    assert proposal.duplicate_status is ImportDuplicateStatus.ALREADY_BOUND
+
+
+def test_exact_asset_metadata_match_is_advisory_not_automatic_duplicate() -> None:
+    existing = Asset.create(
+        name="Ceiling light",
+        asset_type="light_point",
+        area_id="living_room",
+        capabilities=["on_off"],
+    )
+
+    proposal = ImportProposal.create(
+        source=_source(),
+        asset=_asset_candidate(),
+        bindings=[_binding_candidate()],
+        existing_assets=[existing],
+    )
+
+    assert proposal.duplicate_status is ImportDuplicateStatus.POSSIBLE_ASSET_MATCH
+    assert proposal.merge_candidate_asset_ids == (existing.id,)
+
+
+def test_multiple_asset_metadata_matches_require_explicit_review() -> None:
+    first = Asset.create(
+        name="Ceiling light",
+        asset_type="light_point",
+        area_id="living_room",
+        capabilities=["on_off"],
+    )
+    second = Asset.create(
+        name="Ceiling light",
+        asset_type="light_point",
+        area_id="living_room",
+        capabilities=["on_off"],
+    )
+
+    proposal = ImportProposal.create(
+        source=_source(),
+        asset=_asset_candidate(),
+        bindings=[_binding_candidate()],
+        existing_assets=[first, second],
+    )
+
+    assert proposal.duplicate_status is ImportDuplicateStatus.AMBIGUOUS
+    assert set(proposal.merge_candidate_asset_ids) == {first.id, second.id}
+
+
+def test_create_decision_can_rename_and_reclassify_before_commit() -> None:
+    proposal = ImportProposal.create(
+        source=_source(),
+        asset=_asset_candidate(),
+        bindings=[_binding_candidate()],
+    )
+    reviewed_asset = ImportAssetCandidate.create(
+        name="Main ceiling light",
+        asset_type="ceiling_light",
+        area_id="living_room",
+        capabilities=["on_off"],
+    )
+    decision = ImportDecision.create(
+        action=ImportDecisionAction.CREATE,
+        asset=reviewed_asset,
+        bindings=proposal.bindings,
+    )
+
+    accepted = apply_import_decision(proposal, decision)
+
+    assert accepted is not None
+    assert accepted.action is ImportDecisionAction.CREATE
+    assert accepted.asset == reviewed_asset
+    assert accepted.bindings == proposal.bindings
+    assert accepted.source == proposal.source
+
+
+def test_create_decision_can_explicitly_drop_all_candidate_bindings() -> None:
+    proposal = ImportProposal.create(
+        source=_source(),
+        asset=_asset_candidate(),
+        bindings=[_binding_candidate()],
+    )
+    decision = ImportDecision.create(
+        action="create",
+        asset=proposal.asset,
+        bindings=(),
+    )
+
+    accepted = apply_import_decision(proposal, decision)
+
+    assert accepted is not None
+    assert accepted.bindings == ()
+
+
+def test_merge_decision_targets_existing_asset_without_creating_one() -> None:
+    proposal = ImportProposal.create(
+        source=_source(),
+        asset=_asset_candidate(),
+        bindings=[_binding_candidate()],
+    )
+    decision = ImportDecision.create(
+        action="merge",
+        target_asset_id="asset-existing",
+    )
+
+    accepted = apply_import_decision(proposal, decision)
+
+    assert accepted is not None
+    assert accepted.action is ImportDecisionAction.MERGE
+    assert accepted.asset is None
+    assert accepted.target_asset_id == "asset-existing"
+    assert accepted.bindings == proposal.bindings
+
+
+def test_skip_decision_materializes_nothing() -> None:
+    proposal = ImportProposal.create(
+        source=_source(),
+        asset=_asset_candidate(),
+        bindings=[_binding_candidate()],
+    )
+
+    decision = ImportDecision.create(action="skip")
+
+    assert apply_import_decision(proposal, decision) is None
+
+
+def test_binding_candidate_requires_declared_asset_capability() -> None:
+    with pytest.raises(ValueError, match="undeclared capabilities"):
+        ImportProposal.create(
+            source=_source(),
+            asset=_asset_candidate(capabilities=()),
+            bindings=[_binding_candidate()],
+        )
+
+
+def test_invalid_decision_shapes_fail_before_commit() -> None:
+    with pytest.raises(ValueError, match="Create decision"):
+        ImportDecision.create(action="create")
+
+    with pytest.raises(ValueError, match="Merge decision"):
+        ImportDecision.create(action="merge")
+
+    with pytest.raises(ValueError, match="Skip decision"):
+        ImportDecision.create(
+            action="skip",
+            target_asset_id="asset-existing",
+        )


### PR DESCRIPTION
## Summary

- define one pure intermediate proposal model shared by assisted-import discovery, review and commit;
- keep candidate Asset data separate from candidate Binding data;
- retain Home Assistant Area, Device, entity and stable Entity Registry identities for workflow traceability;
- make stable Binding target identity the definitive duplicate signal and keep display-name/type/Area matches advisory only;
- define explicit create, merge and skip outcomes, including editable Asset data for rename/reclassification before commit;
- materialize accepted proposals into commit-ready data without mutating BindHome or Home Assistant;
- document rerun, ambiguity and transaction-boundary rules for the implementation slices under #38.

## Tests

Pure tests cover one-entity and multi-entity devices, entity-without-device discovery, already-bound stable targets, state-only fallbacks, repeated imports, advisory/ambiguous Asset matches and create/merge/skip decisions.

No Home Assistant runtime dependency, Registry schema change or persistence migration is introduced.

Closes #55.