### PR TITLE
feat: surface actionable integrity repairs

### DIFF
--- a/custom_components/bindhome/__init__.py
+++ b/custom_components/bindhome/__init__.py
@@ -13,6 +13,7 @@ from .backup_websocket import async_register_backup_websocket_commands
 from .binding_events import BindingTargetEventTracker
 from .const import DOMAIN
 from .deletion_websocket import async_register_deletion_websocket_commands
+from .integrity_repairs import IntegrityRepairTracker
 from .manager import BindHomeManager
 from .panel import async_register_panel, async_unregister_panel
 from .recovery import async_clear_recovery_state, async_set_recovery_state
@@ -51,6 +52,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: BindHomeConfigEntry) -> 
     binding_target_tracker = BindingTargetEventTracker(hass, manager)
     binding_target_tracker.async_setup()
     entry.async_on_unload(binding_target_tracker.async_unload)
+
+    integrity_repair_tracker = IntegrityRepairTracker(hass, manager, entry.entry_id)
+    integrity_repair_tracker.async_setup()
+    entry.async_on_unload(integrity_repair_tracker.async_unload)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     await async_register_panel(hass)

--- a/custom_components/bindhome/integrity_repairs.py
+++ b/custom_components/bindhome/integrity_repairs.py
@@ -1,0 +1,154 @@
+"""Actionable Home Assistant Repairs for BindHome integrity problems."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import DOMAIN, SIGNAL_BINDING_TARGET_CHANGED, SIGNAL_REGISTRY_CHANGED
+from .manager import BindHomeManager
+from .resolver import ResolutionStatus
+
+_STALE_AREAS_PREFIX = "stale_areas"
+_STALE_BINDINGS_PREFIX = "stale_bindings"
+_SUMMARY_LIMIT = 8
+
+
+def _issue_id(prefix: str, entry_id: str) -> str:
+    return f"{prefix}_{entry_id}"
+
+
+def _summary(values: list[str]) -> str:
+    """Return a bounded human summary without exposing raw UUID-heavy output."""
+    visible = values[:_SUMMARY_LIMIT]
+    text = ", ".join(visible)
+    if len(values) > _SUMMARY_LIMIT:
+        text += "…"
+    return text
+
+
+class IntegrityRepairTracker:
+    """Keep actionable integrity Repairs synchronized with live BindHome state."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        manager: BindHomeManager,
+        entry_id: str,
+    ) -> None:
+        self._hass = hass
+        self._manager = manager
+        self._entry_id = entry_id
+        self._unsubs: list[Callable[[], None]] = []
+
+    def async_setup(self) -> None:
+        """Subscribe to changes that can create or resolve integrity problems."""
+        self._unsubs = [
+            async_dispatcher_connect(
+                self._hass,
+                SIGNAL_REGISTRY_CHANGED,
+                self._handle_change,
+            ),
+            async_dispatcher_connect(
+                self._hass,
+                SIGNAL_BINDING_TARGET_CHANGED,
+                self._handle_change,
+            ),
+            self._hass.bus.async_listen(
+                ar.EVENT_AREA_REGISTRY_UPDATED,
+                self._handle_area_registry_change,
+            ),
+        ]
+        self._refresh()
+
+    def async_unload(self) -> None:
+        """Release listeners while leaving persistent Repairs for next setup."""
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
+
+    @callback
+    def _handle_change(self, *_args: Any) -> None:
+        self._refresh()
+
+    @callback
+    def _handle_area_registry_change(self, _event: Event) -> None:
+        self._refresh()
+
+    @callback
+    def _refresh(self) -> None:
+        """Reconcile grouped Repairs from the current authoritative read model."""
+        self._sync_stale_areas()
+        self._sync_stale_bindings()
+
+    @callback
+    def _sync_stale_areas(self) -> None:
+        area_registry = ar.async_get(self._hass)
+        affected = sorted(
+            (
+                asset
+                for asset in self._manager.registry.assets.values()
+                if asset.area_id is not None
+                and area_registry.async_get_area(asset.area_id) is None
+            ),
+            key=lambda asset: (asset.name.casefold(), asset.id),
+        )
+        issue_id = _issue_id(_STALE_AREAS_PREFIX, self._entry_id)
+        if not affected:
+            ir.async_delete_issue(self._hass, DOMAIN, issue_id)
+            return
+
+        ir.async_create_issue(
+            self._hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="stale_areas",
+            translation_placeholders={
+                "count": str(len(affected)),
+                "assets": _summary([asset.name for asset in affected]),
+            },
+        )
+
+    @callback
+    def _sync_stale_bindings(self) -> None:
+        affected: list[str] = []
+        for binding in self._manager.registry.bindings.values():
+            resolution = self._manager.resolver.resolve(
+                binding.asset_id,
+                binding.capability,
+                binding.role,
+            )
+            if resolution.status is not ResolutionStatus.ENTITY_NOT_FOUND:
+                continue
+
+            asset = self._manager.registry.assets.get(binding.asset_id)
+            asset_name = asset.name if asset is not None else binding.asset_id
+            affected.append(f"{asset_name} — {binding.capability}/{binding.role}")
+
+        affected.sort(key=str.casefold)
+        issue_id = _issue_id(_STALE_BINDINGS_PREFIX, self._entry_id)
+        if not affected:
+            ir.async_delete_issue(self._hass, DOMAIN, issue_id)
+            return
+
+        ir.async_create_issue(
+            self._hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="stale_bindings",
+            translation_placeholders={
+                "count": str(len(affected)),
+                "bindings": _summary(affected),
+            },
+        )

--- a/custom_components/bindhome/translations/en.json
+++ b/custom_components/bindhome/translations/en.json
@@ -64,7 +64,15 @@
     "registry_recovery": {
       "title": "BindHome needs Registry recovery",
       "description": "BindHome could not safely load its Registry ({reason}): {message}. Normal BindHome operation remains disabled to protect stored infrastructure data. Restore a valid BindHome backup through the administrator recovery API, then reload the integration."
-    }
+    },
+    "stale_areas": {
+    "title": "BindHome has elements assigned to missing Areas",
+    "description": "{count} BindHome elements reference Home Assistant Areas that no longer exist: {assets}. Open BindHome, edit the affected elements and assign an existing room or choose no room. This Repair clears automatically when every stale Area reference is fixed."
+  },
+  "stale_bindings": {
+    "title": "BindHome has connections to missing entities",
+    "description": "{count} BindHome connections point to Home Assistant entities that no longer exist: {bindings}. Open the affected element in BindHome and change or disconnect the connection. Temporarily unavailable hardware does not create this Repair. This Repair clears automatically when every broken connection is fixed."
+  }
   },
   "common": {
     "panel_common_floor": "Floor",

--- a/custom_components/bindhome/translations/es.json
+++ b/custom_components/bindhome/translations/es.json
@@ -64,7 +64,15 @@
     "registry_recovery": {
       "title": "BindHome necesita recuperar el Registry",
       "description": "BindHome no ha podido cargar el Registry de forma segura ({reason}): {message}. El funcionamiento normal permanece desactivado para proteger los datos de infraestructura almacenados. Restaura una copia de seguridad válida de BindHome mediante la API de recuperación para administradores y vuelve a cargar la integración."
-    }
+    },
+    "stale_areas": {
+    "title": "BindHome tiene elementos asignados a Áreas inexistentes",
+    "description": "{count} elementos de BindHome hacen referencia a Áreas de Home Assistant que ya no existen: {assets}. Abre BindHome, edita los elementos afectados y asigna una estancia existente o déjalos sin estancia. Esta reparación desaparece automáticamente cuando se corrigen todas las referencias obsoletas."
+  },
+  "stale_bindings": {
+    "title": "BindHome tiene conexiones con entidades inexistentes",
+    "description": "{count} conexiones de BindHome apuntan a entidades de Home Assistant que ya no existen: {bindings}. Abre el elemento afectado en BindHome y cambia o desconecta la conexión. El hardware temporalmente no disponible no genera esta reparación. Esta reparación desaparece automáticamente cuando se corrigen todas las conexiones rotas."
+  }
   },
   "common": {
     "panel_common_floor": "Planta",

--- a/docs/integrity-repairs.md
+++ b/docs/integrity-repairs.md
@@ -1,0 +1,46 @@
+# Integrity Repairs
+
+BindHome uses Home Assistant Repairs only for persistent integrity conditions where the user has a concrete supported action. Normal runtime status remains in the resolver/panel and does not become a Repair merely because hardware is temporarily offline.
+
+## Conditions that create Repairs
+
+### Missing Area references
+
+BindHome Assets store a reference to a Home Assistant Area. If that Area no longer exists, BindHome keeps the stale reference rather than silently moving the physical Asset.
+
+All affected Assets are grouped into one warning Repair per BindHome config entry. The Repair lists the affected physical elements and directs the user to edit them in BindHome and either assign an existing room or choose no room.
+
+The Repair clears automatically when no Asset retains a stale Area reference.
+
+### Missing Binding targets
+
+A Binding needs repair when its configured Home Assistant target can no longer be resolved because the referenced entity has been removed. This includes deletion of a stable Entity Registry target and missing state-only fallback entities.
+
+All broken Bindings are grouped into one warning Repair per BindHome config entry. The Repair identifies the affected Asset/capability/role combinations and directs the user to change or disconnect those connections in BindHome.
+
+A normal Entity Registry rename does not create a Repair because stable target identity follows the renamed entity. Rebinding or removing the broken Binding clears the Repair automatically once no broken target remains.
+
+## Conditions that do not create Repairs
+
+Transient runtime conditions are not configuration problems. A valid target that is currently `unavailable`, `unknown` or otherwise lacks a usable runtime state remains a normal resolver/panel status and does not create a Repair.
+
+The existing critical Registry recovery Repair is also separate. Corrupt/unsupported persistent Registry state continues to use the fail-closed recovery path in `recovery.py`; integrity tracking does not duplicate or replace it.
+
+## Grouping policy
+
+BindHome intentionally creates at most two ordinary integrity Repairs per loaded config entry:
+
+- missing Areas;
+- missing Binding targets.
+
+This avoids one Repair per Asset or Binding while keeping each remediation path specific. Human summaries are bounded so a large broken inventory does not flood the Repairs UI with raw identifiers.
+
+## Event-driven lifecycle
+
+Integrity Repairs are reconciled without polling. The tracker refreshes on:
+
+- committed BindHome Registry changes;
+- relevant stable Binding target changes from Home Assistant's Entity Registry;
+- Home Assistant Area Registry updates.
+
+This means Repairs appear and disappear as the underlying authoritative state changes, without a separate persistent BindHome issue database.

--- a/tests/test_integrity_repairs.py
+++ b/tests/test_integrity_repairs.py
@@ -1,0 +1,249 @@
+"""Lifecycle tests for actionable BindHome integrity Repairs."""
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import issue_registry as ir
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bindhome import async_setup
+from custom_components.bindhome.const import DOMAIN
+
+
+@pytest.fixture
+async def bindhome_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Set up BindHome with integrity Repair tracking enabled."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    await async_setup(hass, {})
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+def _issue(hass: HomeAssistant, entry_id: str, kind: str):
+    return ir.async_get(hass).async_get_issue(DOMAIN, f"{kind}_{entry_id}")
+
+
+async def test_stale_area_repair_appears_and_resolves_after_asset_update(
+    hass: HomeAssistant,
+    bindhome_entry: MockConfigEntry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+    asset = await manager.async_create_asset(
+        name="Hall socket",
+        asset_type="socket",
+        code=None,
+        area_id="area-that-no-longer-exists",
+        capabilities=[],
+    )
+    await hass.async_block_till_done()
+
+    issue = _issue(hass, bindhome_entry.entry_id, "stale_areas")
+    assert issue is not None
+    assert issue.translation_key == "stale_areas"
+    assert issue.translation_placeholders["count"] == "1"
+    assert issue.translation_placeholders["assets"] == "Hall socket"
+
+    await manager.async_update_asset(
+        asset_id=asset.id,
+        name=asset.name,
+        asset_type=asset.asset_type,
+        code=asset.code,
+        area_id=None,
+        capabilities=list(asset.capabilities),
+    )
+    await hass.async_block_till_done()
+
+    assert _issue(hass, bindhome_entry.entry_id, "stale_areas") is None
+
+
+async def test_deleting_home_assistant_area_creates_grouped_repair(
+    hass: HomeAssistant,
+    bindhome_entry: MockConfigEntry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+    area_registry = ar.async_get(hass)
+    area = area_registry.async_create("Utility room")
+
+    for name in ("Boiler", "Pump"):
+        await manager.async_create_asset(
+            name=name,
+            asset_type="equipment",
+            code=None,
+            area_id=area.id,
+            capabilities=[],
+        )
+    await hass.async_block_till_done()
+    assert _issue(hass, bindhome_entry.entry_id, "stale_areas") is None
+
+    area_registry.async_delete(area.id)
+    await hass.async_block_till_done()
+
+    issue = _issue(hass, bindhome_entry.entry_id, "stale_areas")
+    assert issue is not None
+    assert issue.translation_placeholders["count"] == "2"
+    assert issue.translation_placeholders["assets"] == "Boiler, Pump"
+
+
+async def test_entity_registry_deletion_creates_and_rebind_resolves_repair(
+    hass: HomeAssistant,
+    bindhome_entry: MockConfigEntry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+    asset = await manager.async_create_asset(
+        name="Ceiling light",
+        asset_type="light_point",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    entity_registry = er.async_get(hass)
+    original = entity_registry.async_get_or_create(
+        "switch",
+        "demo",
+        "old-relay",
+        suggested_object_id="old_relay",
+    )
+    await manager.async_set_binding(
+        asset_id=asset.id,
+        capability="on_off",
+        entity_id=original.entity_id,
+        role="primary",
+    )
+    await hass.async_block_till_done()
+    assert _issue(hass, bindhome_entry.entry_id, "stale_bindings") is None
+
+    entity_registry.async_remove(original.entity_id)
+    await hass.async_block_till_done()
+
+    issue = _issue(hass, bindhome_entry.entry_id, "stale_bindings")
+    assert issue is not None
+    assert issue.translation_key == "stale_bindings"
+    assert issue.translation_placeholders["count"] == "1"
+    assert (
+        issue.translation_placeholders["bindings"] == "Ceiling light — on_off/primary"
+    )
+
+    replacement = entity_registry.async_get_or_create(
+        "switch",
+        "demo",
+        "new-relay",
+        suggested_object_id="new_relay",
+    )
+    await manager.async_set_binding(
+        asset_id=asset.id,
+        capability="on_off",
+        entity_id=replacement.entity_id,
+        role="primary",
+    )
+    await hass.async_block_till_done()
+
+    assert _issue(hass, bindhome_entry.entry_id, "stale_bindings") is None
+
+
+async def test_multiple_broken_bindings_share_one_repair(
+    hass: HomeAssistant,
+    bindhome_entry: MockConfigEntry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+    entity_registry = er.async_get(hass)
+
+    for index, name in enumerate(("Lamp A", "Lamp B")):
+        asset = await manager.async_create_asset(
+            name=name,
+            asset_type="light_point",
+            code=None,
+            area_id=None,
+            capabilities=["on_off"],
+        )
+        entity = entity_registry.async_get_or_create(
+            "switch",
+            "demo",
+            f"relay-{index}",
+            suggested_object_id=f"relay_{index}",
+        )
+        await manager.async_set_binding(
+            asset_id=asset.id,
+            capability="on_off",
+            entity_id=entity.entity_id,
+            role="primary",
+        )
+        entity_registry.async_remove(entity.entity_id)
+
+    await hass.async_block_till_done()
+
+    issue = _issue(hass, bindhome_entry.entry_id, "stale_bindings")
+    assert issue is not None
+    assert issue.translation_placeholders["count"] == "2"
+    assert "Lamp A — on_off/primary" in issue.translation_placeholders["bindings"]
+    assert "Lamp B — on_off/primary" in issue.translation_placeholders["bindings"]
+
+
+async def test_runtime_unavailable_does_not_create_repair(
+    hass: HomeAssistant,
+    bindhome_entry: MockConfigEntry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+    asset = await manager.async_create_asset(
+        name="Offline relay",
+        asset_type="switch",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get_or_create(
+        "switch",
+        "demo",
+        "offline-relay",
+        suggested_object_id="offline_relay",
+    )
+    hass.states.async_set(entity.entity_id, "unavailable")
+    await manager.async_set_binding(
+        asset_id=asset.id,
+        capability="on_off",
+        entity_id=entity.entity_id,
+        role="primary",
+    )
+    await hass.async_block_till_done()
+
+    assert _issue(hass, bindhome_entry.entry_id, "stale_bindings") is None
+
+
+async def test_entity_rename_remains_resolved_and_does_not_create_repair(
+    hass: HomeAssistant,
+    bindhome_entry: MockConfigEntry,
+) -> None:
+    manager = bindhome_entry.runtime_data
+    asset = await manager.async_create_asset(
+        name="Rename-safe relay",
+        asset_type="switch",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get_or_create(
+        "switch",
+        "demo",
+        "rename-safe",
+        suggested_object_id="rename_safe",
+    )
+    await manager.async_set_binding(
+        asset_id=asset.id,
+        capability="on_off",
+        entity_id=entity.entity_id,
+        role="primary",
+    )
+
+    entity_registry.async_update_entity(
+        entity.entity_id,
+        new_entity_id="switch.renamed_relay",
+    )
+    await hass.async_block_till_done()
+
+    assert _issue(hass, bindhome_entry.entry_id, "stale_bindings") is None
+    resolution = manager.resolver.resolve(asset.id, "on_off")
+    assert resolution.entity_id == "switch.renamed_relay"


### PR DESCRIPTION
## Summary

- add event-driven Home Assistant Repairs for stale Asset Area references and missing Binding targets;
- group affected items into at most one Repair per problem type/config entry to avoid Repair spam;
- refresh from committed Registry changes, relevant Entity Registry target changes and Area Registry updates without polling;
- keep Entity Registry renames transparent and exclude transient `unavailable`/`unknown` runtime states from Repairs;
- automatically clear each Repair when the underlying configuration problem is fixed;
- preserve the existing critical Registry recovery Repair as the separate fail-closed recovery path;
- add actionable EN/ES Repair text and document the grouping/lifecycle policy.

## Tests

Covers stale-Area create/resolve lifecycle, Home Assistant Area deletion, Entity Registry target deletion and rebind recovery, grouped broken Bindings, transient runtime unavailability and rename-safe stable targets.

Closes #47.