### PR TITLE
feat: add transactional CSV inventory round-trip

### DIFF
--- a/custom_components/bindhome/__init__.py
+++ b/custom_components/bindhome/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.typing import ConfigType
 from .backup_websocket import async_register_backup_websocket_commands
 from .binding_events import BindingTargetEventTracker
 from .const import DOMAIN
+from .csv_websocket import async_register_csv_websocket_commands
 from .deletion_websocket import async_register_deletion_websocket_commands
 from .integrity_repairs import IntegrityRepairTracker
 from .manager import BindHomeManager
@@ -33,6 +34,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async_register_services(hass)
     async_register_websocket_commands(hass)
     async_register_backup_websocket_commands(hass)
+    async_register_csv_websocket_commands(hass)
     async_register_deletion_websocket_commands(hass)
     return True
 

--- a/custom_components/bindhome/csv_inventory.py
+++ b/custom_components/bindhome/csv_inventory.py
@@ -1,0 +1,343 @@
+"""Human-editable CSV round-trip for BindHome Asset inventory."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from io import StringIO
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar
+
+from .manager import BindHomeManager
+from .models import Asset, ModelValidationError
+from .registry import BindHomeRegistry, RegistryError, RegistryNotFoundError
+
+CSV_FORMAT_VERSION = "1"
+CSV_COLUMNS = (
+    "bindhome_csv_version",
+    "asset_id",
+    "code",
+    "name",
+    "asset_type",
+    "area_id",
+    "area_name",
+    "capabilities",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CsvRowError:
+    """One validation error tied to a human-visible CSV row and field."""
+
+    row: int
+    field: str | None
+    message: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the row error for APIs and UI."""
+        return {"row": self.row, "field": self.field, "message": self.message}
+
+
+class CsvBatchValidationError(ValueError):
+    """Reject a CSV batch before any Registry mutation is committed."""
+
+    def __init__(self, errors: list[CsvRowError]) -> None:
+        self.errors = tuple(errors)
+        super().__init__(f"CSV validation failed with {len(errors)} error(s)")
+
+
+@dataclass(frozen=True, slots=True)
+class CsvChange:
+    """One validated create/update operation from a CSV row."""
+
+    row: int
+    operation: str
+    name: str
+    asset_id: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the validated change without exposing temporary create IDs."""
+        return {
+            "row": self.row,
+            "operation": self.operation,
+            "name": self.name,
+            "asset_id": self.asset_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CsvImportPreview:
+    """Validated summary of a complete CSV batch."""
+
+    changes: tuple[CsvChange, ...]
+
+    @property
+    def created(self) -> int:
+        return sum(change.operation == "create" for change in self.changes)
+
+    @property
+    def updated(self) -> int:
+        return sum(change.operation == "update" for change in self.changes)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize preview counters and row-level operations."""
+        return {
+            "created": self.created,
+            "updated": self.updated,
+            "total": len(self.changes),
+            "changes": [change.to_dict() for change in self.changes],
+        }
+
+
+def export_inventory_csv(hass: HomeAssistant, registry: BindHomeRegistry) -> str:
+    """Export Assets as deterministic UTF-8 CSV text."""
+    area_registry = ar.async_get(hass)
+    output = StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=CSV_COLUMNS, lineterminator="\n")
+    writer.writeheader()
+    for asset in sorted(registry.assets.values(), key=lambda item: item.id):
+        area = (
+            area_registry.async_get_area(asset.area_id)
+            if asset.area_id is not None
+            else None
+        )
+        writer.writerow(
+            {
+                "bindhome_csv_version": CSV_FORMAT_VERSION,
+                "asset_id": asset.id,
+                "code": asset.code or "",
+                "name": asset.name,
+                "asset_type": asset.asset_type,
+                "area_id": asset.area_id or "",
+                "area_name": area.name if area is not None else "",
+                "capabilities": ";".join(asset.capabilities),
+            }
+        )
+    return output.getvalue()
+
+
+def _normalized_fieldnames(fieldnames: list[str] | None) -> tuple[str, ...]:
+    if fieldnames is None:
+        return ()
+    normalized = list(fieldnames)
+    if normalized:
+        normalized[0] = normalized[0].lstrip("\ufeff")
+    return tuple(normalized)
+
+
+def _rows(csv_text: str) -> list[tuple[int, dict[str, str]]]:
+    reader = csv.DictReader(StringIO(csv_text, newline=""))
+    fieldnames = _normalized_fieldnames(reader.fieldnames)
+    if set(fieldnames) != set(CSV_COLUMNS) or len(fieldnames) != len(CSV_COLUMNS):
+        expected = ", ".join(CSV_COLUMNS)
+        raise CsvBatchValidationError(
+            [CsvRowError(1, None, f"CSV header must contain exactly: {expected}")]
+        )
+
+    rows: list[tuple[int, dict[str, str]]] = []
+    malformed: list[CsvRowError] = []
+    for row_number, raw in enumerate(reader, start=2):
+        if None in raw:
+            malformed.append(
+                CsvRowError(
+                    row_number,
+                    None,
+                    "CSV row contains more columns than the header",
+                )
+            )
+            continue
+        normalized = {
+            str(key).lstrip("\ufeff"): value or "" for key, value in raw.items()
+        }
+        rows.append((row_number, normalized))
+    if malformed:
+        raise CsvBatchValidationError(malformed)
+    if not rows:
+        raise CsvBatchValidationError(
+            [CsvRowError(2, None, "CSV must contain at least one Asset row")]
+        )
+    return rows
+
+
+def _resolve_area_id(
+    hass: HomeAssistant,
+    *,
+    area_id: str,
+    area_name: str,
+    row: int,
+) -> str | None:
+    area_registry = ar.async_get(hass)
+    normalized_id = area_id.strip()
+    if normalized_id:
+        if area_registry.async_get_area(normalized_id) is None:
+            raise CsvBatchValidationError(
+                [
+                    CsvRowError(
+                        row,
+                        "area_id",
+                        f"Home Assistant Area {normalized_id} was not found",
+                    )
+                ]
+            )
+        return normalized_id
+
+    normalized_name = area_name.strip()
+    if not normalized_name:
+        return None
+    matches = [
+        area
+        for area in area_registry.async_list_areas()
+        if area.name.casefold() == normalized_name.casefold()
+    ]
+    if not matches:
+        raise CsvBatchValidationError(
+            [
+                CsvRowError(
+                    row,
+                    "area_name",
+                    f"Home Assistant Area named {normalized_name!r} was not found",
+                )
+            ]
+        )
+    if len(matches) > 1:
+        raise CsvBatchValidationError(
+            [
+                CsvRowError(
+                    row,
+                    "area_name",
+                    f"Home Assistant Area name {normalized_name!r} is ambiguous",
+                )
+            ]
+        )
+    return matches[0].id
+
+
+def _capabilities(raw: str) -> list[str]:
+    return [value.strip() for value in raw.split(";") if value.strip()]
+
+
+def _error_from_exception(row: int, err: Exception) -> CsvRowError:
+    field = getattr(err, "field", None)
+    return CsvRowError(row, field, str(err))
+
+
+def _apply_csv(
+    hass: HomeAssistant,
+    registry: BindHomeRegistry,
+    csv_text: str,
+) -> CsvImportPreview:
+    rows = _rows(csv_text)
+    errors: list[CsvRowError] = []
+    changes: list[CsvChange] = []
+    seen_asset_ids: dict[str, int] = {}
+    seen_codes: dict[str, int] = {}
+
+    for row_number, row in rows:
+        if row["bindhome_csv_version"].strip() != CSV_FORMAT_VERSION:
+            errors.append(
+                CsvRowError(
+                    row_number,
+                    "bindhome_csv_version",
+                    "Unsupported BindHome CSV format version",
+                )
+            )
+            continue
+
+        asset_id = row["asset_id"].strip()
+        code = row["code"].strip() or None
+
+        if asset_id:
+            first_row = seen_asset_ids.get(asset_id)
+            if first_row is not None:
+                errors.append(
+                    CsvRowError(
+                        row_number,
+                        "asset_id",
+                        f"Asset ID is already used by CSV row {first_row}",
+                    )
+                )
+                continue
+            seen_asset_ids[asset_id] = row_number
+
+        if code:
+            first_row = seen_codes.get(code)
+            if first_row is not None:
+                errors.append(
+                    CsvRowError(
+                        row_number,
+                        "code",
+                        f"Asset code is already used by CSV row {first_row}",
+                    )
+                )
+                continue
+            seen_codes[code] = row_number
+
+        try:
+            area_id = _resolve_area_id(
+                hass,
+                area_id=row["area_id"],
+                area_name=row["area_name"],
+                row=row_number,
+            )
+            capabilities = _capabilities(row["capabilities"])
+            if asset_id:
+                registry.get_asset(asset_id)
+                updated = registry.update_asset(
+                    asset_id,
+                    name=row["name"],
+                    asset_type=row["asset_type"],
+                    code=code,
+                    area_id=area_id,
+                    capabilities=capabilities,
+                )
+                changes.append(
+                    CsvChange(row_number, "update", updated.name, updated.id)
+                )
+            else:
+                created = registry.add_asset(
+                    Asset.create(
+                        name=row["name"],
+                        asset_type=row["asset_type"],
+                        code=code,
+                        area_id=area_id,
+                        capabilities=capabilities,
+                    )
+                )
+                changes.append(CsvChange(row_number, "create", created.name, None))
+        except CsvBatchValidationError as err:
+            errors.extend(err.errors)
+        except (ModelValidationError, RegistryError) as err:
+            field = "asset_id" if isinstance(err, RegistryNotFoundError) else None
+            row_error = _error_from_exception(row_number, err)
+            if field is not None and row_error.field is None:
+                row_error = CsvRowError(row_number, field, row_error.message)
+            errors.append(row_error)
+
+    if errors:
+        raise CsvBatchValidationError(errors)
+    return CsvImportPreview(tuple(changes))
+
+
+def validate_inventory_csv(
+    hass: HomeAssistant,
+    registry: BindHomeRegistry,
+    csv_text: str,
+) -> CsvImportPreview:
+    """Validate a complete batch against an isolated Registry copy."""
+    staged = BindHomeRegistry.from_dict(registry.to_dict())
+    return _apply_csv(hass, staged, csv_text)
+
+
+async def async_import_inventory_csv(
+    manager: BindHomeManager,
+    csv_text: str,
+    *,
+    expected_revision: int | None = None,
+) -> CsvImportPreview:
+    """Apply a validated CSV batch as one Registry transaction."""
+    preview: CsvImportPreview | None = None
+    async with manager.transaction(expected_revision=expected_revision) as staged:
+        preview = _apply_csv(manager.hass, staged, csv_text)
+    assert preview is not None
+    return preview

--- a/custom_components/bindhome/csv_websocket.py
+++ b/custom_components/bindhome/csv_websocket.py
@@ -1,0 +1,171 @@
+"""Administrative WebSocket API for human-editable CSV inventory maintenance."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.components import websocket_api
+from homeassistant.components.websocket_api.connection import ActiveConnection
+from homeassistant.components.websocket_api.const import ERR_INVALID_FORMAT
+from homeassistant.components.websocket_api.decorators import (
+    async_response,
+    require_admin,
+    websocket_command,
+)
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .csv_inventory import (
+    CSV_FORMAT_VERSION,
+    CsvBatchValidationError,
+    async_import_inventory_csv,
+    export_inventory_csv,
+    validate_inventory_csv,
+)
+from .manager import BindHomeManager, RegistryRevisionConflictError
+from .registry import RegistryValidationError
+from .store import BindHomeStoreError
+
+WS_CSV_EXPORT = f"{DOMAIN}/csv/export"
+WS_CSV_VALIDATE = f"{DOMAIN}/csv/validate"
+WS_CSV_IMPORT = f"{DOMAIN}/csv/import"
+
+
+def _get_manager(hass: HomeAssistant) -> BindHomeManager:
+    entries = hass.config_entries.async_entries(DOMAIN)
+    if not entries:
+        raise RegistryValidationError("BindHome is not configured")
+    entry = entries[0]
+    if entry.state is not config_entries.ConfigEntryState.LOADED:
+        raise RegistryValidationError("BindHome is not loaded")
+    return cast(BindHomeManager, entry.runtime_data)
+
+
+def _validation_payload(error: CsvBatchValidationError) -> dict[str, object]:
+    return {
+        "valid": False,
+        "format_version": CSV_FORMAT_VERSION,
+        "errors": [item.to_dict() for item in error.errors],
+    }
+
+
+@require_admin
+@websocket_command({vol.Required("type"): WS_CSV_EXPORT})
+def ws_csv_export(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Export the human-maintenance Asset CSV."""
+    try:
+        manager = _get_manager(hass)
+    except RegistryValidationError as err:
+        connection.send_error(msg["id"], ERR_INVALID_FORMAT, str(err))
+        return
+
+    connection.send_result(
+        msg["id"],
+        {
+            "format_version": CSV_FORMAT_VERSION,
+            "csv": export_inventory_csv(hass, manager.registry),
+            "row_count": len(manager.registry.assets),
+        },
+    )
+
+
+@require_admin
+@websocket_command(
+    {
+        vol.Required("type"): WS_CSV_VALIDATE,
+        vol.Required("csv"): str,
+    }
+)
+def ws_csv_validate(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Validate a complete CSV without mutating the live Registry."""
+    try:
+        manager = _get_manager(hass)
+        preview = validate_inventory_csv(hass, manager.registry, msg["csv"])
+    except RegistryValidationError as err:
+        connection.send_error(msg["id"], ERR_INVALID_FORMAT, str(err))
+        return
+    except CsvBatchValidationError as err:
+        connection.send_result(msg["id"], _validation_payload(err))
+        return
+
+    connection.send_result(
+        msg["id"],
+        {
+            "valid": True,
+            "format_version": CSV_FORMAT_VERSION,
+            "errors": [],
+            "preview": preview.to_dict(),
+            "revision": manager.revision,
+        },
+    )
+
+
+@require_admin
+@websocket_command(
+    {
+        vol.Required("type"): WS_CSV_IMPORT,
+        vol.Required("csv"): str,
+        vol.Optional("based_on_revision"): vol.All(int, vol.Range(min=0)),
+    }
+)
+@async_response
+async def ws_csv_import(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Validate and commit the complete CSV as one Registry transaction."""
+    try:
+        manager = _get_manager(hass)
+        preview = await async_import_inventory_csv(
+            manager,
+            msg["csv"],
+            **(
+                {"expected_revision": msg["based_on_revision"]}
+                if "based_on_revision" in msg
+                else {}
+            ),
+        )
+    except CsvBatchValidationError as err:
+        payload = _validation_payload(err)
+        payload["imported"] = False
+        connection.send_result(msg["id"], payload)
+        return
+    except RegistryRevisionConflictError as err:
+        connection.send_error(msg["id"], "conflict", str(err))
+        return
+    except BindHomeStoreError as err:
+        connection.send_error(msg["id"], "storage_error", str(err))
+        return
+    except RegistryValidationError as err:
+        connection.send_error(msg["id"], ERR_INVALID_FORMAT, str(err))
+        return
+
+    connection.send_result(
+        msg["id"],
+        {
+            "imported": True,
+            "valid": True,
+            "format_version": CSV_FORMAT_VERSION,
+            "errors": [],
+            "preview": preview.to_dict(),
+            "revision": manager.revision,
+        },
+    )
+
+
+def async_register_csv_websocket_commands(hass: HomeAssistant) -> None:
+    """Register CSV inventory commands."""
+    websocket_api.async_register_command(hass, ws_csv_export)
+    websocket_api.async_register_command(hass, ws_csv_validate)
+    websocket_api.async_register_command(hass, ws_csv_import)

--- a/docs/csv-inventory.md
+++ b/docs/csv-inventory.md
@@ -1,0 +1,52 @@
+# CSV inventory round-trip
+
+BindHome CSV is a **human-maintenance interchange format** for Asset inventory. It is not the Registry storage format and it is not a machine backup. Use the backup/restore contract for disaster recovery.
+
+## Format version 1
+
+Files are UTF-8 CSV and export these stable columns:
+
+| Column | Meaning |
+| --- | --- |
+| `bindhome_csv_version` | Must be `1` for every row. |
+| `asset_id` | Stable BindHome Asset ID. Empty means create a new Asset; a value means update exactly that existing Asset. |
+| `code` | Optional human Asset code. Must remain unique. |
+| `name` | Required human-readable Asset name. |
+| `asset_type` | Required generic `lower_snake_case` Asset type. |
+| `area_id` | Optional stable Home Assistant Area ID. Authoritative when present. |
+| `area_name` | Human-readable Area name. Exported for spreadsheets; when `area_id` is empty it may resolve a uniquely named HA Area. |
+| `capabilities` | Optional `;`-separated capability identifiers. |
+
+The export keeps both `area_id` and `area_name` so a spreadsheet remains readable without weakening identity. If an Area is renamed in Home Assistant, an existing `area_id` remains authoritative and the exported display name updates on the next export.
+
+## Create and update rules
+
+- Empty `asset_id` means **create**. BindHome generates the stable Asset ID during the committed import.
+- Non-empty `asset_id` means **update that exact Asset**. An unknown ID is an error; BindHome never interprets it as a request to create an Asset with a caller-chosen ID.
+- Duplicate Asset IDs or codes in one CSV are errors.
+- Existing Registry uniqueness, capability and Representation/Binding invariants still apply.
+- `area_id` must identify a current Home Assistant Area. If it is empty and `area_name` is present, the name must match exactly one current Area (case-insensitive).
+- The import never creates, renames, deletes or reassigns Home Assistant Areas, Devices or Entities.
+
+## Validation and transaction boundary
+
+The administrative WebSocket API exposes:
+
+- `bindhome/csv/export`
+- `bindhome/csv/validate`
+- `bindhome/csv/import`
+
+All three are administrator-only in v1.4. CSV is an inventory-management/export surface, not a household read surface.
+
+`validate` applies the complete file to an isolated Registry copy and returns row/field errors plus a create/update preview. It does not mutate runtime state or storage.
+
+`import` repeats the same validation inside the public BindHome transaction boundary and persists once. Any CSV validation error, Registry invariant error, revision conflict or storage failure leaves the live Registry unchanged. Clients may pass `based_on_revision` from the validation response to reject a commit based on stale data.
+
+A typical safe workflow is therefore:
+
+1. Export.
+2. Edit in a spreadsheet without changing stable IDs accidentally.
+3. Validate the complete CSV.
+4. Review row-level errors and the create/update preview.
+5. Import using the validated Registry revision.
+6. Export again if a canonical post-import spreadsheet is required.

--- a/tests/test_csv_inventory.py
+++ b/tests/test_csv_inventory.py
@@ -1,0 +1,162 @@
+"""Tests for BindHome human-editable CSV inventory round-trip."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar
+
+from custom_components.bindhome.csv_inventory import (
+    CSV_COLUMNS,
+    CSV_FORMAT_VERSION,
+    CsvBatchValidationError,
+    async_import_inventory_csv,
+    export_inventory_csv,
+    validate_inventory_csv,
+)
+from custom_components.bindhome.manager import BindHomeManager
+from custom_components.bindhome.models import Asset
+from custom_components.bindhome.registry import BindHomeRegistry
+from custom_components.bindhome.store import BindHomeStoreError
+
+
+def _csv(*rows: str) -> str:
+    return ",".join(CSV_COLUMNS) + "\n" + "\n".join(rows) + "\n"
+
+
+def test_export_round_trip_preserves_unicode_quotes_and_area(
+    hass: HomeAssistant,
+) -> None:
+    area = ar.async_get(hass).async_create("Salón, principal")
+    registry = BindHomeRegistry()
+    asset = registry.add_asset(
+        Asset.create(
+            name="Lámpara, Águeda",
+            asset_type="light_point",
+            code="LGT,01",
+            area_id=area.id,
+            capabilities=["on_off", "brightness"],
+        )
+    )
+
+    exported = export_inventory_csv(hass, registry)
+    assert f'"{asset.name}"' in exported
+    assert '"LGT,01"' in exported
+    assert '"Salón, principal"' in exported
+
+    preview = validate_inventory_csv(hass, registry, exported)
+    assert preview.created == 0
+    assert preview.updated == 1
+    assert preview.changes[0].asset_id == asset.id
+
+
+def test_create_row_can_resolve_area_by_unique_name(hass: HomeAssistant) -> None:
+    area = ar.async_get(hass).async_create("Cocina")
+    text = _csv(f"{CSV_FORMAT_VERSION},,SOCK-01,Enchufe,socket,,Cocina,on_off")
+
+    registry = BindHomeRegistry()
+    preview = validate_inventory_csv(hass, registry, text)
+
+    assert preview.created == 1
+    assert registry.assets == {}
+    assert area.id
+
+
+def test_unknown_asset_id_and_duplicate_codes_are_reported(hass: HomeAssistant) -> None:
+    text = _csv(
+        f"{CSV_FORMAT_VERSION},missing,SAME,One,socket,,,on_off",
+        f"{CSV_FORMAT_VERSION},,SAME,Two,socket,,,on_off",
+    )
+
+    with pytest.raises(CsvBatchValidationError) as exc:
+        validate_inventory_csv(hass, BindHomeRegistry(), text)
+
+    errors = [error.to_dict() for error in exc.value.errors]
+    assert any(error["field"] == "asset_id" for error in errors)
+    assert any(error["field"] == "code" for error in errors)
+
+
+async def test_invalid_row_prevents_whole_import(hass: HomeAssistant) -> None:
+    manager = BindHomeManager(hass)
+    original = manager.registry.add_asset(
+        Asset.create(name="Existing", asset_type="socket", code="EX-01")
+    )
+    manager._store.async_save = AsyncMock()  # noqa: SLF001
+    text = _csv(
+        f"{CSV_FORMAT_VERSION},,NEW-01,Valid,socket,,,on_off",
+        f"{CSV_FORMAT_VERSION},,BAD-01,Bad,Bad Type,,,on_off",
+    )
+
+    with pytest.raises(CsvBatchValidationError):
+        await async_import_inventory_csv(manager, text)
+
+    assert list(manager.registry.assets) == [original.id]
+    manager._store.async_save.assert_not_awaited()  # noqa: SLF001
+
+
+async def test_persistence_failure_preserves_live_registry(hass: HomeAssistant) -> None:
+    manager = BindHomeManager(hass)
+    original = manager.registry.add_asset(
+        Asset.create(name="Existing", asset_type="socket", code="EX-01")
+    )
+    manager._store.async_save = AsyncMock(  # noqa: SLF001
+        side_effect=BindHomeStoreError("disk full")
+    )
+    text = _csv(f"{CSV_FORMAT_VERSION},,NEW-01,New,socket,,,on_off")
+
+    with pytest.raises(BindHomeStoreError, match="disk full"):
+        await async_import_inventory_csv(manager, text)
+
+    assert list(manager.registry.assets) == [original.id]
+
+
+def test_empty_optional_fields_and_utf8_bom_are_supported(hass: HomeAssistant) -> None:
+    text = "\ufeff" + _csv(f"{CSV_FORMAT_VERSION},,,Ático sensor,sensor,,,")
+
+    preview = validate_inventory_csv(hass, BindHomeRegistry(), text)
+
+    assert preview.created == 1
+
+
+def test_duplicate_asset_ids_are_rejected(hass: HomeAssistant) -> None:
+    registry = BindHomeRegistry()
+    asset = registry.add_asset(
+        Asset.create(name="Existing", asset_type="socket", code="EX-01")
+    )
+    text = _csv(
+        f"{CSV_FORMAT_VERSION},{asset.id},EX-01,Existing,socket,,,on_off",
+        f"{CSV_FORMAT_VERSION},{asset.id},EX-02,Again,socket,,,on_off",
+    )
+
+    with pytest.raises(CsvBatchValidationError) as exc:
+        validate_inventory_csv(hass, registry, text)
+
+    assert any(error.field == "asset_id" for error in exc.value.errors)
+
+
+async def test_successful_import_commits_once(hass: HomeAssistant) -> None:
+    manager = BindHomeManager(hass)
+    manager._store.async_save = AsyncMock()  # noqa: SLF001
+    text = _csv(f"{CSV_FORMAT_VERSION},,NEW-01,New socket,socket,,,on_off")
+
+    preview = await async_import_inventory_csv(manager, text)
+
+    assert preview.created == 1
+    assert len(manager.registry.assets) == 1
+    manager._store.async_save.assert_awaited_once()  # noqa: SLF001
+    assert manager.revision == 1
+
+
+def test_large_batch_validates_without_mutating_live_registry(
+    hass: HomeAssistant,
+) -> None:
+    rows = [
+        f"{CSV_FORMAT_VERSION},,CODE-{index},Socket {index},socket,,,on_off"
+        for index in range(300)
+    ]
+    registry = BindHomeRegistry()
+
+    preview = validate_inventory_csv(hass, registry, _csv(*rows))
+
+    assert preview.created == 300
+    assert registry.assets == {}

--- a/tests/test_csv_websocket.py
+++ b/tests/test_csv_websocket.py
@@ -1,0 +1,121 @@
+"""Tests for BindHome CSV inventory WebSocket registration and responses."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from homeassistant import config_entries
+
+from custom_components.bindhome import csv_websocket
+from custom_components.bindhome.csv_inventory import (
+    CsvBatchValidationError,
+    CsvRowError,
+)
+from custom_components.bindhome.registry import BindHomeRegistry
+
+
+class FakeConnection:
+    """Capture WebSocket responses without a live WebSocket client."""
+
+    def __init__(self) -> None:
+        self.user = SimpleNamespace(is_admin=True)
+        self.results: list[tuple[str, object]] = []
+        self.errors: list[tuple[str, str, str]] = []
+
+    def send_result(self, message_id: str, result: object = None) -> None:
+        self.results.append((message_id, result))
+
+    def send_error(self, message_id: str, code: str, message: str) -> None:
+        self.errors.append((message_id, code, message))
+
+
+class FakeManager:
+    """Minimal loaded manager surface for CSV handlers."""
+
+    def __init__(self) -> None:
+        self.registry = BindHomeRegistry()
+        self.revision = 7
+
+
+def _hass(manager: FakeManager) -> SimpleNamespace:
+    entry = SimpleNamespace(
+        state=config_entries.ConfigEntryState.LOADED,
+        runtime_data=manager,
+    )
+    return SimpleNamespace(
+        config_entries=SimpleNamespace(async_entries=lambda domain: [entry]),
+        data={},
+    )
+
+
+def _call_sync(handler, hass, connection, msg):
+    """Call through require_admin for a synchronous WebSocket handler."""
+    return handler.__wrapped__(hass, connection, msg)
+
+
+def _call_async(handler, hass, connection, msg):
+    """Call through require_admin and async_response for an async handler."""
+    return handler.__wrapped__.__wrapped__(hass, connection, msg)
+
+
+def test_registers_csv_commands_under_bindhome_namespace() -> None:
+    hass = SimpleNamespace(data={})
+
+    csv_websocket.async_register_csv_websocket_commands(hass)
+
+    assert set(hass.data["websocket_api"]) == {
+        csv_websocket.WS_CSV_EXPORT,
+        csv_websocket.WS_CSV_VALIDATE,
+        csv_websocket.WS_CSV_IMPORT,
+    }
+
+
+def test_validate_returns_structured_row_errors(monkeypatch) -> None:
+    manager = FakeManager()
+    error = CsvBatchValidationError([CsvRowError(4, "asset_type", "bad type")])
+    validator = Mock(side_effect=error)
+    monkeypatch.setattr(csv_websocket, "validate_inventory_csv", validator)
+    connection = FakeConnection()
+
+    _call_sync(
+        csv_websocket.ws_csv_validate,
+        _hass(manager),
+        connection,
+        {"id": "1", "csv": "bad"},
+    )
+
+    assert connection.errors == []
+    assert connection.results == [
+        (
+            "1",
+            {
+                "valid": False,
+                "format_version": "1",
+                "errors": [{"row": 4, "field": "asset_type", "message": "bad type"}],
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_import_passes_revision_and_returns_committed_revision(
+    monkeypatch,
+) -> None:
+    manager = FakeManager()
+    manager.revision = 8
+    preview = SimpleNamespace(to_dict=lambda: {"created": 1, "updated": 0, "total": 1})
+    importer = AsyncMock(return_value=preview)
+    monkeypatch.setattr(csv_websocket, "async_import_inventory_csv", importer)
+    connection = FakeConnection()
+
+    await _call_async(
+        csv_websocket.ws_csv_import,
+        _hass(manager),
+        connection,
+        {"id": "2", "csv": "ok", "based_on_revision": 7},
+    )
+
+    importer.assert_awaited_once_with(manager, "ok", expected_revision=7)
+    assert connection.errors == []
+    assert connection.results[0][1]["imported"] is True
+    assert connection.results[0][1]["revision"] == 8


### PR DESCRIPTION
## Summary

- add a versioned UTF-8 CSV interchange format for human Asset inventory maintenance;
- export stable Asset IDs plus human-readable Area names while keeping Home Assistant Area IDs authoritative;
- make create/update semantics explicit: empty `asset_id` creates, non-empty `asset_id` updates exactly that existing Asset;
- validate the complete file against an isolated Registry copy and return row/field errors before any write;
- commit a valid import through one existing BindHome transaction, with optional optimistic revision protection;
- preserve Registry state on validation or storage failure and never mutate Home Assistant Areas, Devices or Entities;
- expose administrator-only `bindhome/csv/export`, `bindhome/csv/validate` and `bindhome/csv/import` WebSocket commands;
- document format version 1, column semantics, Area resolution and the safe spreadsheet workflow.

## Tests

Covers quoted commas, accents/Unicode, Area metadata, create/update preview, unknown IDs, duplicate codes/IDs, UTF-8 BOM and empty optional fields, validation atomicity, storage-failure rollback, successful single-commit import and a 300-row batch.

Closes #48.