### PR TITLE
feat: discover assisted import proposals from Home Assistant

### DIFF
--- a/custom_components/bindhome/__init__.py
+++ b/custom_components/bindhome/__init__.py
@@ -14,6 +14,7 @@ from .binding_events import BindingTargetEventTracker
 from .const import DOMAIN
 from .csv_websocket import async_register_csv_websocket_commands
 from .deletion_websocket import async_register_deletion_websocket_commands
+from .import_websocket import async_register_import_websocket_commands
 from .integrity_repairs import IntegrityRepairTracker
 from .manager import BindHomeManager
 from .panel import async_register_panel, async_unregister_panel
@@ -35,6 +36,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async_register_websocket_commands(hass)
     async_register_backup_websocket_commands(hass)
     async_register_csv_websocket_commands(hass)
+    async_register_import_websocket_commands(hass)
     async_register_deletion_websocket_commands(hass)
     return True
 

--- a/custom_components/bindhome/import_discovery.py
+++ b/custom_components/bindhome/import_discovery.py
@@ -1,0 +1,315 @@
+"""Read-only assisted-import discovery from Home Assistant metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+
+from .import_proposals import (
+    ImportAssetCandidate,
+    ImportBindingCandidate,
+    ImportProposal,
+    ImportSource,
+)
+from .registry import BindHomeRegistry
+
+
+@dataclass(frozen=True, slots=True)
+class _EntityHint:
+    asset_type: str
+    capabilities: tuple[str, ...]
+
+
+_DOMAIN_HINTS: dict[str, _EntityHint] = {
+    "light": _EntityHint("light_point", ("on_off",)),
+    "switch": _EntityHint("switch", ("on_off",)),
+    "fan": _EntityHint("fan", ("on_off",)),
+    "cover": _EntityHint("cover", ("open_close",)),
+    "valve": _EntityHint("valve", ("open_close",)),
+    "climate": _EntityHint("thermostat", ("setpoint",)),
+}
+_SENSOR_HINTS: dict[str, _EntityHint] = {
+    "temperature": _EntityHint("sensor", ("temperature",)),
+    "power": _EntityHint("sensor", ("power_measurement",)),
+}
+_BINARY_SENSOR_HINTS: dict[str, _EntityHint] = {
+    "door": _EntityHint("door", ("open_close",)),
+    "window": _EntityHint("window", ("open_close",)),
+    "opening": _EntityHint("opening", ("open_close",)),
+}
+
+
+class ImportDiscoveryError(ValueError):
+    """Reject an invalid discovery scope without mutating anything."""
+
+
+def _domain(entity_id: str) -> str:
+    return entity_id.partition(".")[0]
+
+
+def _device_class_value(entry: er.RegistryEntry) -> str | None:
+    value = entry.device_class or entry.original_device_class
+    if value is None:
+        return None
+    return str(getattr(value, "value", value))
+
+
+def _hint_for_entry(entry: er.RegistryEntry) -> _EntityHint | None:
+    domain = _domain(entry.entity_id)
+    if domain == "sensor":
+        device_class = _device_class_value(entry)
+        return _SENSOR_HINTS.get(device_class or "")
+    if domain == "binary_sensor":
+        device_class = _device_class_value(entry)
+        return _BINARY_SENSOR_HINTS.get(device_class or "")
+    return _DOMAIN_HINTS.get(domain)
+
+
+def _hint_for_state(state: State) -> _EntityHint | None:
+    """Return only domain-level hints that do not require Registry metadata."""
+    return _DOMAIN_HINTS.get(_domain(state.entity_id))
+
+
+def _entry_name(entry: er.RegistryEntry) -> str:
+    return entry.name or entry.original_name or entry.entity_id
+
+
+def _effective_area(
+    device: dr.DeviceEntry | None,
+    entries: tuple[er.RegistryEntry, ...],
+) -> str | None:
+    if device is not None and device.area_id is not None:
+        return device.area_id
+    entity_areas = {entry.area_id for entry in entries if entry.area_id is not None}
+    if len(entity_areas) == 1:
+        return next(iter(entity_areas))
+    return None
+
+
+def _matches_scope(
+    *,
+    selected_area_id: str | None,
+    candidate_area_id: str | None,
+    entries: tuple[er.RegistryEntry, ...],
+) -> bool:
+    if selected_area_id is None:
+        return True
+    if candidate_area_id == selected_area_id:
+        return True
+    return any(entry.area_id == selected_area_id for entry in entries)
+
+
+def _bindings_for_entry(entry: er.RegistryEntry) -> tuple[ImportBindingCandidate, ...]:
+    hint = _hint_for_entry(entry)
+    if hint is None:
+        return ()
+    return tuple(
+        ImportBindingCandidate.create(
+            capability=capability,
+            entity_id=entry.entity_id,
+            entity_registry_id=entry.id,
+        )
+        for capability in hint.capabilities
+    )
+
+
+def _proposal_from_entries(
+    *,
+    registry: BindHomeRegistry,
+    device: dr.DeviceEntry | None,
+    entries: tuple[er.RegistryEntry, ...],
+    candidate_key: str,
+    name: str,
+    selected_area_id: str | None,
+) -> ImportProposal | None:
+    hints = tuple(
+        hint for entry in entries if (hint := _hint_for_entry(entry)) is not None
+    )
+    if not hints:
+        return None
+
+    area_id = _effective_area(device, entries)
+    if not _matches_scope(
+        selected_area_id=selected_area_id,
+        candidate_area_id=area_id,
+        entries=entries,
+    ):
+        return None
+
+    asset_types = {hint.asset_type for hint in hints}
+    asset_type = next(iter(asset_types)) if len(asset_types) == 1 else "device"
+    bindings = tuple(
+        binding for entry in entries for binding in _bindings_for_entry(entry)
+    )
+    capabilities = tuple(sorted({binding.capability for binding in bindings}))
+    source = ImportSource.create(
+        area_id=area_id,
+        device_id=device.id if device is not None else None,
+        entity_ids=(entry.entity_id for entry in entries),
+        entity_registry_ids=(entry.id for entry in entries),
+    )
+    return ImportProposal.create(
+        source=source,
+        asset=ImportAssetCandidate.create(
+            name=name,
+            asset_type=asset_type,
+            area_id=area_id,
+            capabilities=capabilities,
+        ),
+        bindings=bindings,
+        existing_assets=registry.assets.values(),
+        existing_bindings=registry.bindings.values(),
+        candidate_key=candidate_key,
+    )
+
+
+def _device_proposals(
+    *,
+    registry: BindHomeRegistry,
+    device: dr.DeviceEntry,
+    entries: tuple[er.RegistryEntry, ...],
+    selected_area_id: str | None,
+) -> list[ImportProposal]:
+    supported = tuple(
+        entry
+        for entry in entries
+        if entry.disabled_by is None
+        and entry.platform != "bindhome"
+        and _hint_for_entry(entry) is not None
+    )
+    if not supported:
+        return []
+
+    binding_keys: list[tuple[str, str]] = []
+    for entry in supported:
+        binding_keys.extend(
+            (binding.capability, binding.role) for binding in _bindings_for_entry(entry)
+        )
+
+    # A single physical HA Device may expose multiple independently replaceable
+    # channels (for example a two-channel relay). Never collapse conflicting
+    # capability/role keys into one BindHome Asset. Separate proposals remain
+    # mergeable by the human review step.
+    has_conflicting_keys = len(binding_keys) != len(set(binding_keys))
+    if has_conflicting_keys:
+        proposals: list[ImportProposal] = []
+        for entry in supported:
+            proposal = _proposal_from_entries(
+                registry=registry,
+                device=device,
+                entries=(entry,),
+                candidate_key=entry.id,
+                name=_entry_name(entry),
+                selected_area_id=selected_area_id,
+            )
+            if proposal is not None:
+                proposals.append(proposal)
+        return proposals
+
+    proposal = _proposal_from_entries(
+        registry=registry,
+        device=device,
+        entries=supported,
+        candidate_key=device.id,
+        name=device.name_by_user or device.name or _entry_name(supported[0]),
+        selected_area_id=selected_area_id,
+    )
+    return [proposal] if proposal is not None else []
+
+
+def discover_import_proposals(
+    hass: HomeAssistant,
+    registry: BindHomeRegistry,
+    *,
+    area_id: str | None = None,
+) -> list[ImportProposal]:
+    """Discover reviewable proposals without changing HA or BindHome state."""
+    if area_id is not None and ar.async_get(hass).async_get_area(area_id) is None:
+        raise ImportDiscoveryError(f"Home Assistant Area {area_id} was not found")
+
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+    proposals: list[ImportProposal] = []
+    seen_entity_ids: set[str] = set()
+    entries = tuple(
+        sorted(
+            entity_registry.entities.values(),
+            key=lambda item: item.entity_id,
+        )
+    )
+
+    entries_by_device: dict[str, list[er.RegistryEntry]] = {}
+    for entry in entries:
+        if entry.device_id is not None:
+            entries_by_device.setdefault(entry.device_id, []).append(entry)
+
+    for device_id in sorted(entries_by_device):
+        device = device_registry.async_get(device_id)
+        if device is None:
+            continue
+        device_entries = tuple(entries_by_device[device_id])
+        seen_entity_ids.update(entry.entity_id for entry in device_entries)
+        proposals.extend(
+            _device_proposals(
+                registry=registry,
+                device=device,
+                entries=device_entries,
+                selected_area_id=area_id,
+            )
+        )
+
+    for entry in entries:
+        if entry.entity_id in seen_entity_ids:
+            continue
+        if entry.disabled_by is not None or entry.platform == "bindhome":
+            continue
+        proposal = _proposal_from_entries(
+            registry=registry,
+            device=None,
+            entries=(entry,),
+            candidate_key=entry.id,
+            name=_entry_name(entry),
+            selected_area_id=area_id,
+        )
+        if proposal is not None:
+            proposals.append(proposal)
+        seen_entity_ids.add(entry.entity_id)
+
+    # State-machine-only entities have no stable Registry identity. They are
+    # still useful as explicit fallback proposals for whole-install discovery,
+    # but they cannot be safely assigned to an Area by discovery alone.
+    if area_id is None:
+        for state in sorted(hass.states.async_all(), key=lambda item: item.entity_id):
+            if state.entity_id in seen_entity_ids:
+                continue
+            hint = _hint_for_state(state)
+            if hint is None:
+                continue
+            source = ImportSource.create(entity_ids=(state.entity_id,))
+            bindings = tuple(
+                ImportBindingCandidate.create(
+                    capability=capability,
+                    entity_id=state.entity_id,
+                )
+                for capability in hint.capabilities
+            )
+            proposals.append(
+                ImportProposal.create(
+                    source=source,
+                    asset=ImportAssetCandidate.create(
+                        name=state.name,
+                        asset_type=hint.asset_type,
+                        capabilities=hint.capabilities,
+                    ),
+                    bindings=bindings,
+                    existing_assets=registry.assets.values(),
+                    existing_bindings=registry.bindings.values(),
+                    candidate_key=state.entity_id,
+                )
+            )
+
+    return sorted(proposals, key=lambda proposal: proposal.proposal_id)

--- a/custom_components/bindhome/import_websocket.py
+++ b/custom_components/bindhome/import_websocket.py
@@ -1,0 +1,76 @@
+"""Administrative WebSocket API for assisted Home Assistant import discovery."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.components import websocket_api
+from homeassistant.components.websocket_api.connection import ActiveConnection
+from homeassistant.components.websocket_api.const import ERR_INVALID_FORMAT
+from homeassistant.components.websocket_api.decorators import (
+    require_admin,
+    websocket_command,
+)
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .import_discovery import ImportDiscoveryError, discover_import_proposals
+from .manager import BindHomeManager
+from .registry import RegistryValidationError
+
+WS_IMPORT_DISCOVER = f"{DOMAIN}/import/discover"
+
+
+def _get_manager(hass: HomeAssistant) -> BindHomeManager:
+    entries = hass.config_entries.async_entries(DOMAIN)
+    if not entries:
+        raise RegistryValidationError("BindHome is not configured")
+    entry = entries[0]
+    if entry.state is not config_entries.ConfigEntryState.LOADED:
+        raise RegistryValidationError("BindHome is not loaded")
+    return cast(BindHomeManager, entry.runtime_data)
+
+
+@require_admin
+@websocket_command(
+    {
+        vol.Required("type"): WS_IMPORT_DISCOVER,
+        vol.Optional("area_id"): str,
+    }
+)
+def ws_import_discover(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return non-mutating assisted-import proposals for review."""
+    try:
+        manager = _get_manager(hass)
+        proposals = discover_import_proposals(
+            hass,
+            manager.registry,
+            area_id=msg.get("area_id"),
+        )
+    except (ImportDiscoveryError, RegistryValidationError) as err:
+        connection.send_error(msg["id"], ERR_INVALID_FORMAT, str(err))
+        return
+
+    connection.send_result(
+        msg["id"],
+        {
+            "scope": {
+                "type": "area" if msg.get("area_id") is not None else "all",
+                "area_id": msg.get("area_id"),
+            },
+            "revision": manager.revision,
+            "count": len(proposals),
+            "proposals": [proposal.to_dict() for proposal in proposals],
+        },
+    )
+
+
+def async_register_import_websocket_commands(hass: HomeAssistant) -> None:
+    """Register assisted-import read commands."""
+    websocket_api.async_register_command(hass, ws_import_discover)

--- a/docs/assisted-import.md
+++ b/docs/assisted-import.md
@@ -119,3 +119,34 @@ The commit step must not modify Home Assistant Areas, Devices or Entities.
 Proposal IDs are deterministic workflow identifiers derived from Home Assistant source identities plus a discovery-provided candidate key. They are not persistent infrastructure identity and must not be used as Asset IDs.
 
 The Python contract in `custom_components/bindhome/import_proposals.py` is the canonical shape for implementation work under #38. Backend discovery and frontend review should serialize that contract rather than defining parallel structures.
+
+## Discovery implementation in v1.4
+
+`bindhome/import/discover` implements the read-only discovery slice. It is administrator-only until the household-read authorization matrix explicitly classifies assisted-import metadata. It accepts an optional Home Assistant `area_id`; without one it scans the whole installation.
+
+Discovery reads current Area, Device, Entity Registry and state-machine metadata and serializes the canonical proposal contract above. It never writes the BindHome Registry or Home Assistant registries.
+
+### Conservative metadata mapping
+
+The first implementation proposes capabilities only where Home Assistant metadata provides a reasonably stable meaning:
+
+- `light`, `switch`, `fan` -> `on_off`;
+- `cover`, `valve` -> `open_close`;
+- `climate` -> `setpoint`;
+- temperature sensors -> `temperature`;
+- power sensors -> `power_measurement`;
+- door/window/opening binary sensors -> `open_close`.
+
+Unsupported metadata is not translated into an invented capability. Every mapping remains a proposal that the review step may rename, reclassify, merge or skip.
+
+### Device grouping
+
+Device-backed entities are grouped only while proposed `(capability, role)` keys remain non-conflicting. A Device exposing two switch channels therefore becomes two reviewable proposals instead of one Asset with two competing primary `on_off` Bindings. Non-conflicting functions can remain together. The human review step may explicitly merge proposals when that reflects the real physical installation.
+
+### Stable identity and fallbacks
+
+Entity Registry entry IDs are retained as the strong target identity. A Home Assistant entity rename updates the current `entity_id` without changing the stable proposal identity where Registry identity exists.
+
+State-machine-only entities are included only during whole-installation discovery and use the explicit `entity_id` fallback defined by the contract. Discovery does not guess an Area for them.
+
+The discovery response also includes the current BindHome Registry revision so the later reviewed commit can reject stale decisions through optimistic concurrency.

--- a/tests/test_import_discovery.py
+++ b/tests/test_import_discovery.py
@@ -1,0 +1,230 @@
+"""Tests for assisted-import discovery from Home Assistant metadata."""
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bindhome.import_discovery import discover_import_proposals
+from custom_components.bindhome.import_proposals import ImportDuplicateStatus
+from custom_components.bindhome.models import Asset, Binding
+from custom_components.bindhome.registry import BindHomeRegistry
+
+
+def _device(hass: HomeAssistant, *, name: str, area_id: str | None = None):
+    config_entry = MockConfigEntry(domain="demo", data={})
+    config_entry.add_to_hass(hass)
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("demo", name.casefold().replace(" ", "-"))},
+        name=name,
+    )
+    if area_id is not None:
+        dr.async_get(hass).async_update_device(device.id, area_id=area_id)
+        device = dr.async_get(hass).async_get(device.id)
+        assert device is not None
+    return device
+
+
+def _entity(
+    hass: HomeAssistant,
+    domain: str,
+    unique_id: str,
+    *,
+    device_id: str | None = None,
+    area_id: str | None = None,
+    device_class: str | None = None,
+):
+    registry = er.async_get(hass)
+    entry = registry.async_get_or_create(
+        domain,
+        "demo",
+        unique_id,
+        suggested_object_id=unique_id.replace("-", "_"),
+        device_id=device_id,
+        original_device_class=device_class,
+    )
+    if area_id is not None:
+        registry.async_update_entity(entry.entity_id, area_id=area_id)
+        entry = registry.async_get(entry.entity_id)
+        assert entry is not None
+    return entry
+
+
+def test_single_device_entity_becomes_stable_proposal(hass: HomeAssistant) -> None:
+    area = ar.async_get(hass).async_create("Living room")
+    device = _device(hass, name="Ceiling relay", area_id=area.id)
+    entity = _entity(hass, "light", "ceiling-light", device_id=device.id)
+
+    proposals = discover_import_proposals(hass, BindHomeRegistry(), area_id=area.id)
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.asset.name == "Ceiling relay"
+    assert proposal.asset.asset_type == "light_point"
+    assert proposal.asset.area_id == area.id
+    assert proposal.asset.capabilities == ("on_off",)
+    assert proposal.source.device_id == device.id
+    assert proposal.source.entity_registry_ids == (entity.id,)
+    assert proposal.bindings[0].entity_registry_id == entity.id
+    assert proposal.bindings[0].entity_id == entity.entity_id
+
+
+def test_multi_channel_device_splits_conflicting_bindings_for_review(
+    hass: HomeAssistant,
+) -> None:
+    device = _device(hass, name="Two-channel relay")
+    first = _entity(hass, "switch", "relay-one", device_id=device.id)
+    second = _entity(hass, "switch", "relay-two", device_id=device.id)
+
+    proposals = discover_import_proposals(hass, BindHomeRegistry())
+
+    assert len(proposals) == 2
+    assert {proposal.source.device_id for proposal in proposals} == {device.id}
+    assert {proposal.bindings[0].entity_registry_id for proposal in proposals} == {
+        first.id,
+        second.id,
+    }
+    assert all(proposal.asset.capabilities == ("on_off",) for proposal in proposals)
+
+
+def test_non_conflicting_device_entities_can_share_one_proposal(
+    hass: HomeAssistant,
+) -> None:
+    device = _device(hass, name="Thermostat module")
+    climate = _entity(hass, "climate", "thermostat", device_id=device.id)
+    sensor = _entity(
+        hass,
+        "sensor",
+        "room-temperature",
+        device_id=device.id,
+        device_class="temperature",
+    )
+
+    proposals = discover_import_proposals(hass, BindHomeRegistry())
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.asset.asset_type == "device"
+    assert proposal.asset.capabilities == ("setpoint", "temperature")
+    assert proposal.source.entity_registry_ids == tuple(sorted((climate.id, sensor.id)))
+    assert {binding.capability for binding in proposal.bindings} == {
+        "setpoint",
+        "temperature",
+    }
+
+
+def test_entity_without_device_is_discovered_from_area(hass: HomeAssistant) -> None:
+    area = ar.async_get(hass).async_create("Kitchen")
+    entity = _entity(
+        hass,
+        "sensor",
+        "kitchen-temperature",
+        area_id=area.id,
+        device_class="temperature",
+    )
+
+    proposals = discover_import_proposals(hass, BindHomeRegistry(), area_id=area.id)
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.source.device_id is None
+    assert proposal.source.entity_registry_ids == (entity.id,)
+    assert proposal.asset.area_id == area.id
+    assert proposal.asset.capabilities == ("temperature",)
+
+
+def test_area_scope_does_not_return_other_area(hass: HomeAssistant) -> None:
+    kitchen = ar.async_get(hass).async_create("Kitchen")
+    garage = ar.async_get(hass).async_create("Garage")
+    kitchen_device = _device(hass, name="Kitchen relay", area_id=kitchen.id)
+    garage_device = _device(hass, name="Garage relay", area_id=garage.id)
+    _entity(hass, "switch", "kitchen-relay", device_id=kitchen_device.id)
+    _entity(hass, "switch", "garage-relay", device_id=garage_device.id)
+
+    proposals = discover_import_proposals(hass, BindHomeRegistry(), area_id=kitchen.id)
+
+    assert len(proposals) == 1
+    assert proposals[0].asset.name == "Kitchen relay"
+
+
+def test_existing_stable_binding_is_classified_already_bound(
+    hass: HomeAssistant,
+) -> None:
+    entity = _entity(hass, "switch", "bound-relay")
+    registry = BindHomeRegistry()
+    asset = registry.add_asset(
+        Asset.create(
+            name="Existing point",
+            asset_type="switch",
+            capabilities=["on_off"],
+        )
+    )
+    registry.set_binding(
+        Binding.create(
+            asset_id=asset.id,
+            capability="on_off",
+            entity_id=entity.entity_id,
+            entity_registry_id=entity.id,
+        )
+    )
+
+    proposal = discover_import_proposals(hass, registry)[0]
+
+    assert proposal.duplicate_status is ImportDuplicateStatus.ALREADY_BOUND
+    assert proposal.merge_candidate_asset_ids == (asset.id,)
+
+
+def test_entity_rename_keeps_proposal_identity_and_updates_current_entity_id(
+    hass: HomeAssistant,
+) -> None:
+    entity_registry = er.async_get(hass)
+    entity = _entity(hass, "switch", "rename-safe")
+    before = discover_import_proposals(hass, BindHomeRegistry())[0]
+
+    entity_registry.async_update_entity(
+        entity.entity_id,
+        new_entity_id="switch.renamed_hardware",
+    )
+    after = discover_import_proposals(hass, BindHomeRegistry())[0]
+
+    assert after.proposal_id == before.proposal_id
+    assert after.bindings[0].entity_registry_id == entity.id
+    assert after.bindings[0].entity_id == "switch.renamed_hardware"
+
+
+def test_whole_installation_includes_supported_state_only_entity(
+    hass: HomeAssistant,
+) -> None:
+    hass.states.async_set("switch.state_only_relay", "off")
+
+    proposals = discover_import_proposals(hass, BindHomeRegistry())
+
+    proposal = next(
+        item
+        for item in proposals
+        if item.bindings[0].entity_id == "switch.state_only_relay"
+    )
+    assert proposal.source.entity_registry_ids == ()
+    assert proposal.bindings[0].entity_registry_id is None
+
+
+def test_discovery_does_not_mutate_home_assistant_or_registry(
+    hass: HomeAssistant,
+) -> None:
+    device = _device(hass, name="Read only device")
+    _entity(hass, "switch", "read-only-relay", device_id=device.id)
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    registry = BindHomeRegistry()
+    registry_before = registry.to_dict()
+    entity_ids_before = tuple(sorted(entity_registry.entities))
+    device_before = device_registry.async_get(device.id)
+    assert device_before is not None
+
+    discover_import_proposals(hass, registry)
+
+    assert registry.to_dict() == registry_before
+    assert tuple(sorted(entity_registry.entities)) == entity_ids_before
+    assert device_registry.async_get(device.id) == device_before

--- a/tests/test_import_websocket.py
+++ b/tests/test_import_websocket.py
@@ -1,0 +1,73 @@
+"""Tests for assisted-import discovery WebSocket API."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from homeassistant import config_entries
+
+from custom_components.bindhome import import_websocket
+from custom_components.bindhome.registry import BindHomeRegistry
+
+
+class FakeConnection:
+    """Capture WebSocket responses."""
+
+    def __init__(self) -> None:
+        self.user = SimpleNamespace(is_admin=True)
+        self.results: list[tuple[str, object]] = []
+        self.errors: list[tuple[str, str, str]] = []
+
+    def send_result(self, message_id: str, result: object = None) -> None:
+        self.results.append((message_id, result))
+
+    def send_error(self, message_id: str, code: str, message: str) -> None:
+        self.errors.append((message_id, code, message))
+
+
+def _hass() -> tuple[SimpleNamespace, SimpleNamespace]:
+    manager = SimpleNamespace(registry=BindHomeRegistry(), revision=4)
+    entry = SimpleNamespace(
+        state=config_entries.ConfigEntryState.LOADED,
+        runtime_data=manager,
+    )
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_entries=lambda domain: [entry]),
+        data={},
+    )
+    return hass, manager
+
+
+def test_registers_import_discovery_command() -> None:
+    hass = SimpleNamespace(data={})
+
+    import_websocket.async_register_import_websocket_commands(hass)
+
+    assert set(hass.data["websocket_api"]) == {import_websocket.WS_IMPORT_DISCOVER}
+
+
+def test_discovery_response_includes_scope_revision_and_proposals(monkeypatch) -> None:
+    hass, manager = _hass()
+    proposal = SimpleNamespace(to_dict=lambda: {"proposal_id": "proposal-1"})
+    discover = Mock(return_value=[proposal])
+    monkeypatch.setattr(import_websocket, "discover_import_proposals", discover)
+    connection = FakeConnection()
+
+    import_websocket.ws_import_discover.__wrapped__(
+        hass,
+        connection,
+        {"id": "1", "area_id": "living"},
+    )
+
+    discover.assert_called_once_with(hass, manager.registry, area_id="living")
+    assert connection.errors == []
+    assert connection.results == [
+        (
+            "1",
+            {
+                "scope": {"type": "area", "area_id": "living"},
+                "revision": 4,
+                "count": 1,
+                "proposals": [{"proposal_id": "proposal-1"}],
+            },
+        )
+    ]


### PR DESCRIPTION
## Summary

- add administrator-only assisted-import discovery for one HA Area or the whole installation;
- read current Home Assistant Area, Device, Entity Registry and state-machine metadata without mutating HA or the BindHome Registry;
- emit the canonical `ImportProposal` contract from #55, retaining stable Entity Registry IDs for traceability and rerun deduplication;
- use deliberately conservative domain/device-class mappings and never invent unsupported capabilities;
- group Device-backed entities only when proposed Binding keys are non-conflicting; multi-channel conflicts remain separate reviewable proposals;
- include suitable Entity-without-Device candidates and explicit state-machine-only fallbacks during whole-install discovery;
- keep Entity Registry rename behavior stable through Registry entry IDs;
- return the current Registry revision with proposals for the later reviewed commit boundary.

## Tests

Covers Area-scoped discovery, Device-backed entities, conservative multi-channel splitting, non-conflicting Device grouping, Entity-without-Device discovery, stable duplicate classification, Entity Registry rename identity, state-only fallback and proof that discovery mutates neither Home Assistant registries nor BindHome.

Closes #84.