### PR TITLE
feat: commit reviewed assisted imports atomically

### DIFF
--- a/custom_components/bindhome/import_commit.py
+++ b/custom_components/bindhome/import_commit.py
@@ -1,0 +1,311 @@
+"""Transactional commit boundary for reviewed assisted-import decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .binding_identity import entity_registry_id_for_entity
+from .import_proposals import (
+    AcceptedImport,
+    ImportAssetCandidate,
+    ImportBindingCandidate,
+    ImportDecision,
+    ImportDecisionAction,
+    ImportProposal,
+    apply_import_decision,
+)
+from .manager import BindHomeManager, RegistryRevisionConflictError
+from .models import Asset, Binding, normalize_identifier, normalize_non_empty
+from .registry import RegistryConflictError, RegistryValidationError
+from .validation import validate_area
+
+
+@dataclass(frozen=True, slots=True)
+class ImportBindingSelector:
+    """Stable review-side identity for one proposed Binding candidate."""
+
+    capability: str
+    role: str
+    entity_registry_id: str | None
+    entity_id: str | None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        capability: str,
+        role: str = "primary",
+        entity_registry_id: str | None = None,
+        entity_id: str | None = None,
+    ) -> ImportBindingSelector:
+        """Create a selector that prefers stable Entity Registry identity."""
+        normalized_registry_id = (
+            normalize_non_empty(entity_registry_id, "entity_registry_id")
+            if entity_registry_id is not None
+            else None
+        )
+        normalized_entity_id = (
+            normalize_non_empty(entity_id, "entity_id")
+            if entity_id is not None
+            else None
+        )
+        if normalized_registry_id is None and normalized_entity_id is None:
+            raise RegistryValidationError(
+                "Binding selection requires entity_registry_id or entity_id"
+            )
+        return cls(
+            capability=normalize_identifier(capability, "capability"),
+            role=normalize_identifier(role, "role"),
+            entity_registry_id=normalized_registry_id,
+            entity_id=normalized_entity_id,
+        )
+
+
+def _candidate_key(
+    candidate: ImportBindingCandidate,
+) -> tuple[str, str, str, str]:
+    if candidate.entity_registry_id is not None:
+        return (
+            candidate.capability,
+            candidate.role,
+            "registry",
+            candidate.entity_registry_id,
+        )
+    return (candidate.capability, candidate.role, "entity", candidate.entity_id)
+
+
+def _selector_key(selector: ImportBindingSelector) -> tuple[str, str, str, str]:
+    if selector.entity_registry_id is not None:
+        return (
+            selector.capability,
+            selector.role,
+            "registry",
+            selector.entity_registry_id,
+        )
+    assert selector.entity_id is not None
+    return (selector.capability, selector.role, "entity", selector.entity_id)
+
+
+def select_proposal_bindings(
+    proposal: ImportProposal,
+    selectors: tuple[ImportBindingSelector, ...],
+) -> tuple[ImportBindingCandidate, ...]:
+    """Resolve explicit selectors only against candidates in the current proposal."""
+    candidates = {
+        _candidate_key(candidate): candidate for candidate in proposal.bindings
+    }
+    selected: list[ImportBindingCandidate] = []
+    seen: set[tuple[str, str, str, str]] = set()
+
+    for selector in selectors:
+        key = _selector_key(selector)
+        if key in seen:
+            raise RegistryValidationError(
+                f"Binding selection for proposal {proposal.proposal_id} is duplicated"
+            )
+        seen.add(key)
+        candidate = candidates.get(key)
+        if candidate is None:
+            raise RegistryValidationError(
+                "Selected Binding is not part of the current import proposal"
+            )
+        selected.append(candidate)
+
+    return tuple(selected)
+
+
+@dataclass(frozen=True, slots=True)
+class ImportCommitItemResult:
+    """Committed outcome for one explicitly reviewed proposal."""
+
+    proposal_id: str
+    action: ImportDecisionAction
+    asset_id: str | None
+    bindings_applied: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize one commit outcome."""
+        return {
+            "proposal_id": self.proposal_id,
+            "action": self.action.value,
+            "asset_id": self.asset_id,
+            "bindings_applied": self.bindings_applied,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ImportCommitResult:
+    """Summary of one atomic reviewed-import batch."""
+
+    items: tuple[ImportCommitItemResult, ...]
+    revision: int
+
+    @property
+    def created(self) -> int:
+        return sum(item.action is ImportDecisionAction.CREATE for item in self.items)
+
+    @property
+    def merged(self) -> int:
+        return sum(item.action is ImportDecisionAction.MERGE for item in self.items)
+
+    @property
+    def skipped(self) -> int:
+        return sum(item.action is ImportDecisionAction.SKIP for item in self.items)
+
+    @property
+    def bindings_applied(self) -> int:
+        return sum(item.bindings_applied for item in self.items)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize counters and per-proposal results."""
+        return {
+            "created": self.created,
+            "merged": self.merged,
+            "skipped": self.skipped,
+            "bindings_applied": self.bindings_applied,
+            "revision": self.revision,
+            "items": [item.to_dict() for item in self.items],
+        }
+
+
+def _same_target(left: Binding, right: Binding) -> bool:
+    """Compare Binding targets without falling back from stable identity."""
+    if left.entity_registry_id is not None:
+        return left.entity_registry_id == right.entity_registry_id
+    return right.entity_registry_id is None and left.entity_id == right.entity_id
+
+
+def _reject_cross_asset_target_duplicate(
+    proposed: Binding,
+    *,
+    registry_bindings: tuple[Binding, ...],
+) -> None:
+    """Prevent repeat import from creating a second Asset for one stable target."""
+    for existing in registry_bindings:
+        if existing.asset_id == proposed.asset_id:
+            continue
+        if _same_target(proposed, existing):
+            raise RegistryConflictError(
+                "Home Assistant Binding target is already attached to another "
+                f"BindHome Asset ({existing.asset_id})"
+            )
+
+
+def _binding_from_candidate(
+    manager: BindHomeManager,
+    *,
+    asset_id: str,
+    candidate: ImportBindingCandidate,
+) -> Binding:
+    """Re-resolve stable target identity using the normal current HA lookup."""
+    current_registry_id = entity_registry_id_for_entity(
+        manager.hass,
+        candidate.entity_id,
+    )
+    if current_registry_id != candidate.entity_registry_id:
+        raise RegistryConflictError(
+            "Home Assistant Binding target changed after import review; "
+            "run discovery again"
+        )
+    return Binding.create(
+        asset_id=asset_id,
+        capability=candidate.capability,
+        role=candidate.role,
+        entity_id=candidate.entity_id,
+        entity_registry_id=current_registry_id,
+    )
+
+
+def _create_asset(candidate: ImportAssetCandidate) -> Asset:
+    return Asset.create(
+        name=candidate.name,
+        asset_type=candidate.asset_type,
+        code=None,
+        area_id=candidate.area_id,
+        capabilities=list(candidate.capabilities),
+    )
+
+
+async def async_commit_reviewed_imports(
+    manager: BindHomeManager,
+    reviewed: tuple[tuple[ImportProposal, ImportDecision], ...],
+    *,
+    expected_revision: int,
+) -> ImportCommitResult:
+    """Validate and persist one complete reviewed batch atomically."""
+    seen_proposals: set[str] = set()
+    materialized: list[
+        tuple[ImportProposal, ImportDecision, AcceptedImport | None]
+    ] = []
+    for proposal, decision in reviewed:
+        if proposal.proposal_id in seen_proposals:
+            raise RegistryValidationError(
+                f"Import proposal {proposal.proposal_id} has multiple decisions"
+            )
+        seen_proposals.add(proposal.proposal_id)
+        materialized.append(
+            (proposal, decision, apply_import_decision(proposal, decision))
+        )
+
+    if all(accepted is None for _, _, accepted in materialized):
+        if manager.revision != expected_revision:
+            raise RegistryRevisionConflictError(expected_revision, manager.revision)
+        return ImportCommitResult(
+            items=tuple(
+                ImportCommitItemResult(
+                    proposal_id=proposal.proposal_id,
+                    action=decision.action,
+                    asset_id=None,
+                    bindings_applied=0,
+                )
+                for proposal, decision, _ in materialized
+            ),
+            revision=manager.revision,
+        )
+
+    results: list[ImportCommitItemResult] = []
+    async with manager.transaction(expected_revision=expected_revision) as staged:
+        for proposal, decision, accepted in materialized:
+            if accepted is None:
+                results.append(
+                    ImportCommitItemResult(
+                        proposal_id=proposal.proposal_id,
+                        action=decision.action,
+                        asset_id=None,
+                        bindings_applied=0,
+                    )
+                )
+                continue
+
+            if accepted.action is ImportDecisionAction.CREATE:
+                assert accepted.asset is not None
+                validate_area(manager.hass, accepted.asset.area_id)
+                asset = staged.add_asset(_create_asset(accepted.asset))
+            else:
+                assert accepted.action is ImportDecisionAction.MERGE
+                assert accepted.target_asset_id is not None
+                asset = staged.get_asset(accepted.target_asset_id)
+
+            for candidate in accepted.bindings:
+                binding = _binding_from_candidate(
+                    manager,
+                    asset_id=asset.id,
+                    candidate=candidate,
+                )
+                manager._validate_binding_target(binding, registry=staged)
+                _reject_cross_asset_target_duplicate(
+                    binding,
+                    registry_bindings=tuple(staged.bindings.values()),
+                )
+                staged.set_binding(binding)
+
+            results.append(
+                ImportCommitItemResult(
+                    proposal_id=proposal.proposal_id,
+                    action=accepted.action,
+                    asset_id=asset.id,
+                    bindings_applied=len(accepted.bindings),
+                )
+            )
+
+    return ImportCommitResult(items=tuple(results), revision=manager.revision)

--- a/custom_components/bindhome/import_websocket.py
+++ b/custom_components/bindhome/import_websocket.py
@@ -1,4 +1,4 @@
-"""Administrative WebSocket API for assisted Home Assistant import discovery."""
+"""Administrative WebSocket API for assisted Home Assistant import."""
 
 from __future__ import annotations
 
@@ -8,19 +8,71 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api.connection import ActiveConnection
-from homeassistant.components.websocket_api.const import ERR_INVALID_FORMAT
+from homeassistant.components.websocket_api.const import (
+    ERR_INVALID_FORMAT,
+    ERR_NOT_FOUND,
+)
 from homeassistant.components.websocket_api.decorators import (
+    async_response,
     require_admin,
     websocket_command,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 
 from .const import DOMAIN
+from .import_commit import (
+    ImportBindingSelector,
+    async_commit_reviewed_imports,
+    select_proposal_bindings,
+)
 from .import_discovery import ImportDiscoveryError, discover_import_proposals
+from .import_proposals import (
+    ImportAssetCandidate,
+    ImportBindingCandidate,
+    ImportDecision,
+    ImportDecisionAction,
+    ImportProposal,
+)
 from .manager import BindHomeManager
-from .registry import RegistryValidationError
+from .models import ModelValidationError
+from .registry import (
+    RegistryConflictError,
+    RegistryError,
+    RegistryNotFoundError,
+    RegistryValidationError,
+)
 
 WS_IMPORT_DISCOVER = f"{DOMAIN}/import/discover"
+WS_IMPORT_COMMIT = f"{DOMAIN}/import/commit"
+
+_ASSET_REVIEW_SCHEMA = vol.Schema(
+    {
+        vol.Required("name"): str,
+        vol.Required("asset_type"): str,
+        vol.Optional("area_id"): str,
+        vol.Required("capabilities"): [str],
+    }
+)
+_BINDING_SELECTOR_SCHEMA = vol.Schema(
+    {
+        vol.Required("capability"): str,
+        vol.Optional("role", default="primary"): str,
+        vol.Optional("entity_id"): str,
+        vol.Optional("entity_registry_id"): str,
+    }
+)
+_DECISION_SCHEMA = vol.Schema(
+    {
+        vol.Required("proposal_id"): str,
+        vol.Required("action"): vol.In(
+            [action.value for action in ImportDecisionAction]
+        ),
+        vol.Optional("asset"): _ASSET_REVIEW_SCHEMA,
+        vol.Optional("target_asset_id"): str,
+        vol.Optional("bindings"): [_BINDING_SELECTOR_SCHEMA],
+    }
+)
 
 
 def _get_manager(hass: HomeAssistant) -> BindHomeManager:
@@ -31,6 +83,82 @@ def _get_manager(hass: HomeAssistant) -> BindHomeManager:
     if entry.state is not config_entries.ConfigEntryState.LOADED:
         raise RegistryValidationError("BindHome is not loaded")
     return cast(BindHomeManager, entry.runtime_data)
+
+
+def _send_import_error(
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    err: Exception,
+) -> None:
+    """Translate reviewed-import failures to stable WebSocket error classes."""
+    if isinstance(err, (RegistryNotFoundError, ServiceValidationError)):
+        code = ERR_NOT_FOUND
+    elif isinstance(err, RegistryConflictError):
+        code = "conflict"
+    else:
+        code = ERR_INVALID_FORMAT
+    connection.send_error(msg["id"], code, str(err))
+
+
+def _reviewed_asset(payload: dict[str, Any] | None) -> ImportAssetCandidate | None:
+    if payload is None:
+        return None
+    return ImportAssetCandidate.create(
+        name=payload["name"],
+        asset_type=payload["asset_type"],
+        area_id=payload.get("area_id"),
+        capabilities=payload["capabilities"],
+    )
+
+
+def _reviewed_bindings(
+    proposal: ImportProposal,
+    payload: dict[str, Any],
+) -> tuple[ImportBindingCandidate, ...] | None:
+    if "bindings" not in payload:
+        return None
+    selectors = tuple(
+        ImportBindingSelector.create(
+            capability=item["capability"],
+            role=item.get("role", "primary"),
+            entity_id=item.get("entity_id"),
+            entity_registry_id=item.get("entity_registry_id"),
+        )
+        for item in payload["bindings"]
+    )
+    return select_proposal_bindings(proposal, selectors)
+
+
+def _reviewed_decisions(
+    proposals: list[ImportProposal],
+    payloads: list[dict[str, Any]],
+) -> tuple[tuple[ImportProposal, ImportDecision], ...]:
+    by_id = {proposal.proposal_id: proposal for proposal in proposals}
+    reviewed: list[tuple[ImportProposal, ImportDecision]] = []
+    seen: set[str] = set()
+
+    for payload in payloads:
+        proposal_id = payload["proposal_id"]
+        if proposal_id in seen:
+            raise RegistryValidationError(
+                f"Import proposal {proposal_id} has multiple decisions"
+            )
+        seen.add(proposal_id)
+        proposal = by_id.get(proposal_id)
+        if proposal is None:
+            raise RegistryConflictError(
+                f"Import proposal {proposal_id} is no longer available; "
+                "run discovery again"
+            )
+        decision = ImportDecision.create(
+            action=payload["action"],
+            asset=_reviewed_asset(payload.get("asset")),
+            target_asset_id=payload.get("target_asset_id"),
+            bindings=_reviewed_bindings(proposal, payload),
+        )
+        reviewed.append((proposal, decision))
+
+    return tuple(reviewed)
 
 
 @require_admin
@@ -71,6 +199,52 @@ def ws_import_discover(
     )
 
 
+@require_admin
+@websocket_command(
+    {
+        vol.Required("type"): WS_IMPORT_COMMIT,
+        vol.Optional("area_id"): str,
+        vol.Required("based_on_revision"): vol.All(int, vol.Range(min=0)),
+        vol.Required("decisions"): vol.All(
+            [_DECISION_SCHEMA],
+            vol.Length(min=1),
+        ),
+    }
+)
+@async_response
+async def ws_import_commit(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Commit explicitly reviewed current proposals as one Registry transaction."""
+    try:
+        manager = _get_manager(hass)
+        proposals = discover_import_proposals(
+            hass,
+            manager.registry,
+            area_id=msg.get("area_id"),
+        )
+        reviewed = _reviewed_decisions(proposals, msg["decisions"])
+        result = await async_commit_reviewed_imports(
+            manager,
+            reviewed,
+            expected_revision=msg["based_on_revision"],
+        )
+    except (
+        ImportDiscoveryError,
+        ModelValidationError,
+        RegistryError,
+        ServiceValidationError,
+        ValueError,
+    ) as err:
+        _send_import_error(connection, msg, err)
+        return
+
+    connection.send_result(msg["id"], result.to_dict())
+
+
 def async_register_import_websocket_commands(hass: HomeAssistant) -> None:
-    """Register assisted-import read commands."""
+    """Register assisted-import discovery and commit commands."""
     websocket_api.async_register_command(hass, ws_import_discover)
+    websocket_api.async_register_command(hass, ws_import_commit)

--- a/docs/assisted-import.md
+++ b/docs/assisted-import.md
@@ -150,3 +150,15 @@ Entity Registry entry IDs are retained as the strong target identity. A Home Ass
 State-machine-only entities are included only during whole-installation discovery and use the explicit `entity_id` fallback defined by the contract. Discovery does not guess an Area for them.
 
 The discovery response also includes the current BindHome Registry revision so the later reviewed commit can reject stale decisions through optimistic concurrency.
+
+## Transactional commit implementation in v1.4
+
+`bindhome/import/commit` accepts administrator-reviewed `create`, `merge` and `skip` decisions for proposal IDs returned by discovery. The command requires the discovery Registry revision and repeats discovery in the same Area or whole-installation scope before accepting the batch.
+
+The client may edit the final Asset name, type, Area and Capabilities for `create`, and may submit a subset of proposed Bindings. Binding selectors cannot introduce an arbitrary Home Assistant target: registered targets are matched by stable Entity Registry ID, while state-machine-only targets use the explicit `entity_id` fallback. A Home Assistant rename therefore resolves to the current candidate instead of making mutable display identity authoritative.
+
+All non-skipped decisions are applied to the isolated Registry yielded by one `BindHomeManager.transaction()`. Reviewed Areas, merge targets and Binding targets are validated before the transaction can persist. A later validation error discards earlier staged changes, and storage failure occurs before live Registry adoption.
+
+A target already bound to another BindHome Asset is rejected during import commit. Reapplying the same target to the same explicitly selected Asset is allowed, so repeat imports are idempotent rather than creating duplicate physical Assets. Registered Bindings persist the current stable Entity Registry target identity.
+
+The commit workflow never creates, updates, moves or deletes Home Assistant Areas, Devices or Entities.

--- a/tests/test_import_commit.py
+++ b/tests/test_import_commit.py
@@ -1,0 +1,380 @@
+"""Tests for atomic assisted-import commit."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.bindhome.import_commit import (
+    ImportBindingSelector,
+    async_commit_reviewed_imports,
+    select_proposal_bindings,
+)
+from custom_components.bindhome.import_proposals import (
+    ImportAssetCandidate,
+    ImportBindingCandidate,
+    ImportDecision,
+    ImportDecisionAction,
+    ImportProposal,
+    ImportSource,
+)
+from custom_components.bindhome.manager import BindHomeManager
+from custom_components.bindhome.registry import (
+    RegistryConflictError,
+    RegistryNotFoundError,
+)
+
+
+def _proposal(
+    manager: BindHomeManager,
+    *,
+    name: str,
+    entity_id: str,
+    entity_registry_id: str | None = None,
+    candidate_key: str | None = None,
+) -> ImportProposal:
+    return ImportProposal.create(
+        source=ImportSource.create(
+            entity_ids=(entity_id,),
+            entity_registry_ids=(
+                (entity_registry_id,) if entity_registry_id is not None else ()
+            ),
+        ),
+        asset=ImportAssetCandidate.create(
+            name=name,
+            asset_type="switch",
+            capabilities=("on_off",),
+        ),
+        bindings=(
+            ImportBindingCandidate.create(
+                capability="on_off",
+                entity_id=entity_id,
+                entity_registry_id=entity_registry_id,
+            ),
+        ),
+        existing_assets=manager.registry.assets.values(),
+        existing_bindings=manager.registry.bindings.values(),
+        candidate_key=candidate_key or entity_registry_id or entity_id,
+    )
+
+
+async def test_mixed_create_merge_skip_commits_once(hass: HomeAssistant) -> None:
+    hass.states.async_set("switch.new", "off")
+    hass.states.async_set("switch.merge", "off")
+    hass.states.async_set("switch.skip", "off")
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    existing = await manager.async_create_asset(
+        name="Existing point",
+        asset_type="switch",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    revision = manager.revision
+    manager._store.async_save = AsyncMock(wraps=manager._store.async_save)
+
+    create_proposal = _proposal(manager, name="New", entity_id="switch.new")
+    merge_proposal = _proposal(manager, name="Merge", entity_id="switch.merge")
+    skip_proposal = _proposal(manager, name="Skip", entity_id="switch.skip")
+    reviewed_asset = ImportAssetCandidate.create(
+        name="Renamed new point",
+        asset_type="relay_point",
+        capabilities=("on_off",),
+    )
+
+    result = await async_commit_reviewed_imports(
+        manager,
+        (
+            (
+                create_proposal,
+                ImportDecision.create(
+                    action=ImportDecisionAction.CREATE,
+                    asset=reviewed_asset,
+                ),
+            ),
+            (
+                merge_proposal,
+                ImportDecision.create(
+                    action=ImportDecisionAction.MERGE,
+                    target_asset_id=existing.id,
+                ),
+            ),
+            (
+                skip_proposal,
+                ImportDecision.create(action=ImportDecisionAction.SKIP),
+            ),
+        ),
+        expected_revision=revision,
+    )
+
+    assert result.created == 1
+    assert result.merged == 1
+    assert result.skipped == 1
+    assert result.bindings_applied == 2
+    assert result.revision == revision + 1
+    assert manager._store.async_save.await_count == 1
+    created = next(
+        asset for asset in manager.registry.assets.values() if asset.id != existing.id
+    )
+    assert created.name == "Renamed new point"
+    assert created.asset_type == "relay_point"
+    assert {binding.asset_id for binding in manager.registry.bindings.values()} == {
+        existing.id,
+        created.id,
+    }
+
+
+async def test_create_can_accept_zero_bindings(hass: HomeAssistant) -> None:
+    hass.states.async_set("switch.optional", "off")
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    proposal = _proposal(manager, name="Optional relay", entity_id="switch.optional")
+
+    result = await async_commit_reviewed_imports(
+        manager,
+        (
+            (
+                proposal,
+                ImportDecision.create(
+                    action=ImportDecisionAction.CREATE,
+                    asset=ImportAssetCandidate.create(
+                        name="Manual inventory only",
+                        asset_type="electrical_point",
+                        capabilities=(),
+                    ),
+                    bindings=(),
+                ),
+            ),
+        ),
+        expected_revision=manager.revision,
+    )
+
+    assert result.created == 1
+    assert result.bindings_applied == 0
+    assert len(manager.registry.assets) == 1
+    assert manager.registry.bindings == {}
+    asset = next(iter(manager.registry.assets.values()))
+    assert asset.name == "Manual inventory only"
+    assert asset.asset_type == "electrical_point"
+    assert asset.capabilities == ()
+
+
+async def test_invalid_late_target_aborts_complete_batch(hass: HomeAssistant) -> None:
+    hass.states.async_set("switch.first", "off")
+    hass.states.async_set("switch.second", "off")
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    first = _proposal(manager, name="First", entity_id="switch.first")
+    second = _proposal(manager, name="Second", entity_id="switch.second")
+    baseline = manager.registry.to_dict()
+    revision = manager.revision
+    manager._store.async_save = AsyncMock(wraps=manager._store.async_save)
+
+    with pytest.raises(RegistryNotFoundError):
+        await async_commit_reviewed_imports(
+            manager,
+            (
+                (
+                    first,
+                    ImportDecision.create(
+                        action=ImportDecisionAction.CREATE,
+                        asset=first.asset,
+                    ),
+                ),
+                (
+                    second,
+                    ImportDecision.create(
+                        action=ImportDecisionAction.MERGE,
+                        target_asset_id="missing-asset",
+                    ),
+                ),
+            ),
+            expected_revision=revision,
+        )
+
+    assert manager.registry.to_dict() == baseline
+    assert manager.revision == revision
+    assert manager._store.async_save.await_count == 0
+
+
+async def test_storage_failure_preserves_previous_registry(hass: HomeAssistant) -> None:
+    hass.states.async_set("switch.storage", "off")
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    proposal = _proposal(manager, name="Storage", entity_id="switch.storage")
+    baseline = manager.registry.to_dict()
+    revision = manager.revision
+    manager._store.async_save = AsyncMock(side_effect=RuntimeError("storage failed"))
+
+    with pytest.raises(RuntimeError, match="storage failed"):
+        await async_commit_reviewed_imports(
+            manager,
+            (
+                (
+                    proposal,
+                    ImportDecision.create(
+                        action=ImportDecisionAction.CREATE,
+                        asset=proposal.asset,
+                    ),
+                ),
+            ),
+            expected_revision=revision,
+        )
+
+    assert manager.registry.to_dict() == baseline
+    assert manager.revision == revision
+    assert manager._store.async_save.await_count == 1
+
+
+async def test_already_bound_target_cannot_create_duplicate_asset(
+    hass: HomeAssistant,
+) -> None:
+    hass.states.async_set("switch.shared", "off")
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    existing = await manager.async_create_asset(
+        name="Existing",
+        asset_type="switch",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await manager.async_set_binding(
+        asset_id=existing.id,
+        capability="on_off",
+        entity_id="switch.shared",
+        role="primary",
+    )
+    proposal = _proposal(manager, name="Duplicate", entity_id="switch.shared")
+    baseline = manager.registry.to_dict()
+    revision = manager.revision
+
+    with pytest.raises(RegistryConflictError, match="another BindHome Asset"):
+        await async_commit_reviewed_imports(
+            manager,
+            (
+                (
+                    proposal,
+                    ImportDecision.create(
+                        action=ImportDecisionAction.CREATE,
+                        asset=proposal.asset,
+                    ),
+                ),
+            ),
+            expected_revision=revision,
+        )
+
+    assert manager.registry.to_dict() == baseline
+    assert manager.revision == revision
+
+
+async def test_repeat_merge_to_same_asset_is_idempotent(hass: HomeAssistant) -> None:
+    hass.states.async_set("switch.shared", "off")
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    existing = await manager.async_create_asset(
+        name="Existing",
+        asset_type="switch",
+        code=None,
+        area_id=None,
+        capabilities=["on_off"],
+    )
+    await manager.async_set_binding(
+        asset_id=existing.id,
+        capability="on_off",
+        entity_id="switch.shared",
+        role="primary",
+    )
+    original_binding_id = next(iter(manager.registry.bindings))
+    proposal = _proposal(manager, name="Repeat", entity_id="switch.shared")
+
+    result = await async_commit_reviewed_imports(
+        manager,
+        (
+            (
+                proposal,
+                ImportDecision.create(
+                    action=ImportDecisionAction.MERGE,
+                    target_asset_id=existing.id,
+                ),
+            ),
+        ),
+        expected_revision=manager.revision,
+    )
+
+    assert result.merged == 1
+    assert len(manager.registry.assets) == 1
+    assert len(manager.registry.bindings) == 1
+    assert next(iter(manager.registry.bindings)) == original_binding_id
+
+
+async def test_registered_target_persists_stable_identity(hass: HomeAssistant) -> None:
+    entity = er.async_get(hass).async_get_or_create(
+        "switch",
+        "demo",
+        "stable-import",
+        suggested_object_id="stable_import",
+    )
+    manager = BindHomeManager(hass)
+    await manager.async_load()
+    proposal = _proposal(
+        manager,
+        name="Stable",
+        entity_id=entity.entity_id,
+        entity_registry_id=entity.id,
+    )
+
+    await async_commit_reviewed_imports(
+        manager,
+        (
+            (
+                proposal,
+                ImportDecision.create(
+                    action=ImportDecisionAction.CREATE,
+                    asset=proposal.asset,
+                ),
+            ),
+        ),
+        expected_revision=manager.revision,
+    )
+
+    binding = next(iter(manager.registry.bindings.values()))
+    assert binding.entity_registry_id == entity.id
+    assert binding.entity_id == entity.entity_id
+
+
+def test_binding_selection_uses_stable_identity_over_mutable_entity_id() -> None:
+    proposal = ImportProposal.create(
+        source=ImportSource.create(
+            entity_ids=("switch.current",),
+            entity_registry_ids=("registry-1",),
+        ),
+        asset=ImportAssetCandidate.create(
+            name="Relay",
+            asset_type="switch",
+            capabilities=("on_off",),
+        ),
+        bindings=(
+            ImportBindingCandidate.create(
+                capability="on_off",
+                entity_id="switch.current",
+                entity_registry_id="registry-1",
+            ),
+        ),
+    )
+
+    selected = select_proposal_bindings(
+        proposal,
+        (
+            ImportBindingSelector.create(
+                capability="on_off",
+                entity_registry_id="registry-1",
+                entity_id="switch.old_name",
+            ),
+        ),
+    )
+
+    assert selected == proposal.bindings
+    assert selected[0].entity_id == "switch.current"

--- a/tests/test_import_websocket.py
+++ b/tests/test_import_websocket.py
@@ -1,12 +1,19 @@
-"""Tests for assisted-import discovery WebSocket API."""
+"""Tests for assisted-import WebSocket API."""
 
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
 from homeassistant import config_entries
 
 from custom_components.bindhome import import_websocket
-from custom_components.bindhome.registry import BindHomeRegistry
+from custom_components.bindhome.import_proposals import (
+    ImportAssetCandidate,
+    ImportBindingCandidate,
+    ImportProposal,
+    ImportSource,
+)
+from custom_components.bindhome.registry import BindHomeRegistry, RegistryConflictError
 
 
 class FakeConnection:
@@ -37,12 +44,36 @@ def _hass() -> tuple[SimpleNamespace, SimpleNamespace]:
     return hass, manager
 
 
-def test_registers_import_discovery_command() -> None:
+def _proposal() -> ImportProposal:
+    return ImportProposal.create(
+        source=ImportSource.create(
+            entity_ids=("switch.current",),
+            entity_registry_ids=("registry-1",),
+        ),
+        asset=ImportAssetCandidate.create(
+            name="Relay",
+            asset_type="switch",
+            capabilities=("on_off",),
+        ),
+        bindings=(
+            ImportBindingCandidate.create(
+                capability="on_off",
+                entity_id="switch.current",
+                entity_registry_id="registry-1",
+            ),
+        ),
+    )
+
+
+def test_registers_import_commands() -> None:
     hass = SimpleNamespace(data={})
 
     import_websocket.async_register_import_websocket_commands(hass)
 
-    assert set(hass.data["websocket_api"]) == {import_websocket.WS_IMPORT_DISCOVER}
+    assert set(hass.data["websocket_api"]) == {
+        import_websocket.WS_IMPORT_DISCOVER,
+        import_websocket.WS_IMPORT_COMMIT,
+    }
 
 
 def test_discovery_response_includes_scope_revision_and_proposals(monkeypatch) -> None:
@@ -71,3 +102,47 @@ def test_discovery_response_includes_scope_revision_and_proposals(monkeypatch) -
             },
         )
     ]
+
+
+def test_reviewed_decisions_reject_unknown_proposal() -> None:
+    proposal = _proposal()
+
+    with pytest.raises(RegistryConflictError, match="no longer available"):
+        import_websocket._reviewed_decisions(
+            [proposal],
+            [{"proposal_id": "missing", "action": "skip"}],
+        )
+
+
+def test_reviewed_binding_selection_uses_current_candidate() -> None:
+    proposal = _proposal()
+
+    reviewed = import_websocket._reviewed_decisions(
+        [proposal],
+        [
+            {
+                "proposal_id": proposal.proposal_id,
+                "action": "create",
+                "asset": {
+                    "name": "Reviewed relay",
+                    "asset_type": "relay_point",
+                    "capabilities": ["on_off"],
+                },
+                "bindings": [
+                    {
+                        "capability": "on_off",
+                        "role": "primary",
+                        "entity_registry_id": "registry-1",
+                        "entity_id": "switch.old_name",
+                    }
+                ],
+            }
+        ],
+    )
+
+    decision = reviewed[0][1]
+    assert decision.asset is not None
+    assert decision.asset.name == "Reviewed relay"
+    assert decision.asset.asset_type == "relay_point"
+    assert decision.bindings == proposal.bindings
+    assert decision.bindings[0].entity_id == "switch.current"


### PR DESCRIPTION
## Summary

- add an administrator-only `bindhome/import/commit` endpoint for explicitly reviewed assisted-import decisions
- re-run discovery in the submitted scope and resolve every decision against the current canonical `ImportProposal`
- require the Registry revision returned by discovery before any staged mutation
- allow reviewed Asset rename/reclassification/Area/Capability changes for `create`
- allow an explicit Binding subset, including zero selected Bindings, without permitting arbitrary Home Assistant targets
- apply create/merge/skip decisions through one `BindHomeManager.transaction()`
- reuse the existing Binding target/cycle validation and persist stable Entity Registry target identity
- reject one Home Assistant target being imported onto a different BindHome Asset while keeping repeat merge to the same Asset idempotent
- document the transactional commit contract and failure semantics

## Safety

- Home Assistant Areas, Devices and Entities remain read-only
- any validation failure leaves earlier staged import work uncommitted
- storage failure happens before live Registry adoption
- no Registry schema change
- no frontend change

## Tests

- mixed create / merge / skip in one commit
- reviewed rename and reclassification before create
- zero selected Bindings
- invalid late merge target aborts the entire batch before persistence
- storage failure preserves live Registry and revision
- already-bound target cannot create a duplicate Asset
- repeat merge to the same Asset remains idempotent
- registered targets persist stable Entity Registry identity
- stable Binding selection survives a mutable `entity_id` rename

Closes #85