### PR TITLE
feat: add native Home Assistant sidebar access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 
 ### Changed
 
+- The BindHome header now exposes Home Assistant's native sidebar menu control, letting phone/narrow layouts and desktop setups with an always-hidden docked sidebar open HA navigation using the platform's own context, kiosk and notification semantics. ([#115](https://github.com/alessbarb/bindhome/issues/115))
 - Panel preferences for Advanced pinning, onboarding dismissal and collapsed Floors now persist in Home Assistant per-user frontend data so they follow the authenticated user across browsers and devices; existing browser-local values migrate once when the server preference is unset, and explicit user changes cannot be overwritten by a late asynchronous restore. ([#113](https://github.com/alessbarb/bindhome/issues/113))
 - BindHome panel views now have canonical URLs with deep-linkable Home/Area/Asset, Add, Search and Advanced routes; browser history and search query state stay synchronized without remounting active workflows. ([#109](https://github.com/alessbarb/bindhome/issues/109))
 - Home navigation now follows Home Assistant Floor/Area icons more closely, persists collapsed floors per HA user/browser, provides an empty-room first action and exposes an accessible refresh-in-progress state. ([#46](https://github.com/alessbarb/bindhome/issues/46))

--- a/custom_components/bindhome/panel/static/bindhome-panel.js
+++ b/custom_components/bindhome/panel/static/bindhome-panel.js
@@ -3211,7 +3211,7 @@
         </div>
       </div>`:t=this._renderViews(),a`<div class="shell">
       <header class="top">
-        <div class="brand"><ha-icon icon="mdi:home-switch"></ha-icon><h1>BindHome</h1>${this._isAdmin()?c:a`<span class="read-only-badge">${this._t("common.read_only")}</span>`}</div>
+        <div class="leading"><ha-menu-button></ha-menu-button><div class="brand"><ha-icon icon="mdi:home-switch"></ha-icon><h1>BindHome</h1>${this._isAdmin()?c:a`<span class="read-only-badge">${this._t("common.read_only")}</span>`}</div></div>
         <nav class="tabs" aria-label=${this._t("shell.sections_label")}>
           ${["home",...this._isAdmin()?["add"]:[],"search"].map(e=>a`<button
               class=${this._view===e?"active":""}
@@ -3283,6 +3283,8 @@
       border-bottom: 1px solid var(--divider-color, #e0e0e0);
       background: var(--card-background-color, #fff);
     }
+    .leading { display: flex; align-items: center; min-width: 0; }
+    .leading > ha-menu-button { flex: none; }
     .brand { display: flex; align-items: center; gap: 9px; margin-right: 30px; }
     .brand ha-icon { color: var(--primary-color); --mdc-icon-size: 28px; }
     .brand h1 { margin: 0; font-size: 20px; font-weight: 500; }

--- a/frontend/src/bindhome-panel.js
+++ b/frontend/src/bindhome-panel.js
@@ -226,6 +226,8 @@ export class BindHomePanel extends LitElement {
       border-bottom: 1px solid var(--divider-color, #e0e0e0);
       background: var(--card-background-color, #fff);
     }
+    .leading { display: flex; align-items: center; min-width: 0; }
+    .leading > ha-menu-button { flex: none; }
     .brand { display: flex; align-items: center; gap: 9px; margin-right: 30px; }
     .brand ha-icon { color: var(--primary-color); --mdc-icon-size: 28px; }
     .brand h1 { margin: 0; font-size: 20px; font-weight: 500; }
@@ -742,7 +744,7 @@ export class BindHomePanel extends LitElement {
     else content = this._renderViews();
     return html`<div class="shell">
       <header class="top">
-        <div class="brand"><ha-icon icon="mdi:home-switch"></ha-icon><h1>BindHome</h1>${!this._isAdmin() ? html`<span class="read-only-badge">${this._t("common.read_only")}</span>` : nothing}</div>
+        <div class="leading"><ha-menu-button></ha-menu-button><div class="brand"><ha-icon icon="mdi:home-switch"></ha-icon><h1>BindHome</h1>${!this._isAdmin() ? html`<span class="read-only-badge">${this._t("common.read_only")}</span>` : nothing}</div></div>
         <nav class="tabs" aria-label=${this._t("shell.sections_label")}>
           ${["home", ...(this._isAdmin() ? ["add"] : []), "search"].map(
             (view) => html`<button

--- a/frontend/test/native-menu-button.test.js
+++ b/frontend/test/native-menu-button.test.js
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Window } from "happy-dom";
+
+const window = new Window({ url: "http://localhost/bindhome/home" });
+Object.assign(globalThis, {
+  window,
+  document: window.document,
+  customElements: window.customElements,
+  HTMLElement: window.HTMLElement,
+  ShadowRoot: window.ShadowRoot,
+  Document: window.Document,
+  CSSStyleSheet: window.CSSStyleSheet,
+  Event: window.Event,
+  CustomEvent: window.CustomEvent,
+  CSS: window.CSS,
+});
+for (const tag of ["ha-icon", "ha-switch", "ha-menu-button"]) {
+  if (!customElements.get(tag))
+    customElements.define(tag, class extends HTMLElement {});
+}
+
+await import("../src/bindhome-panel.js");
+
+async function settle(element) {
+  await element.updateComplete;
+  await window.happyDOM.waitUntilComplete();
+  await element.updateComplete;
+}
+
+function fixture() {
+  const panel = document.createElement("bindhome-panel");
+  panel.hass = {
+    user: { id: "user", is_admin: true },
+    language: "en",
+    callWS: async () => [],
+    connection: null,
+  };
+  panel.route = { prefix: "/bindhome", path: "/home" };
+  panel._loading = false;
+  panel._initialized = true;
+  panel._t = (key) => key;
+  panel._registry = { assets: [], relations: [], bindings: [], representations: [] };
+  document.body.append(panel);
+  return panel;
+}
+
+test("BindHome header exposes exactly one native Home Assistant menu button", async () => {
+  const panel = fixture();
+  await settle(panel);
+
+  const leading = panel.shadowRoot.querySelector("header.top > .leading");
+  const buttons = panel.shadowRoot.querySelectorAll("ha-menu-button");
+  assert.equal(buttons.length, 1);
+  assert.equal(leading.firstElementChild, buttons[0]);
+  assert.equal(buttons[0].attributes.length, 0);
+});
+
+test("BindHome does not duplicate narrow or sidebar logic around ha-menu-button", async () => {
+  const panel = fixture();
+  panel.narrow = true;
+  await settle(panel);
+  const menu = panel.shadowRoot.querySelector("ha-menu-button");
+  assert.equal(menu.hasAttribute("narrow"), false);
+  assert.equal(menu.hasAttribute("hass"), false);
+
+  panel.narrow = false;
+  await settle(panel);
+  assert.equal(panel.shadowRoot.querySelector("ha-menu-button"), menu);
+});
+
+test("native hass-toggle-menu event remains owned by Home Assistant without remounting views", async () => {
+  const panel = fixture();
+  await settle(panel);
+  const home = panel.shadowRoot.querySelector("bindhome-home-view");
+  let toggles = 0;
+  panel.addEventListener("hass-toggle-menu", () => {
+    toggles += 1;
+  });
+
+  panel.shadowRoot.querySelector("ha-menu-button").dispatchEvent(
+    new CustomEvent("hass-toggle-menu", { bubbles: true, composed: true }),
+  );
+  await settle(panel);
+
+  assert.equal(toggles, 1);
+  assert.equal(panel.shadowRoot.querySelector("bindhome-home-view"), home);
+});


### PR DESCRIPTION
## Summary

- add Home Assistant's native `<ha-menu-button>` at the leading edge of the BindHome header
- rely on HA context for narrow/kiosk/docked-sidebar visibility and the standard `hass-toggle-menu` behavior
- preserve the existing brand, read-only badge, tabs, refresh action and mounted view state
- cover the native header contract with focused frontend tests
- keep the generated production panel bundle synchronized and document the change in Unreleased

## Validation before PR

The isolated generation branch passed the complete frontend suite, typecheck and production build. The final PR branch was then rewritten onto current `main` with only product/test/changelog and generated bundle commits; no temporary workflow is present.

Normal repository CI on the final SHA remains authoritative.

Closes #115

Completes the final implementation slice of #102.