### PR TITLE
release: prepare BindHome 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,36 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 
 ## [Unreleased]
 
+---
+
+## [1.4.0] - 2026-09-06
+
+Maintenance-focused release that turns the stable BindHome model into something easier to inspect, populate, repair and rebind as Home Assistant hardware changes.
+
+**Minimum Home Assistant:** `2026.8.0`
+
+### Added
+
+- Authenticated non-admin users can open BindHome in a read-only household mode. Intended inventory, topology and Binding status reads are available without administrator privileges, while mutations, backup/recovery and administrative internals remain admin-only and write controls are hidden from read-only users. ([#34](https://github.com/alessbarb/bindhome/issues/34))
+- Added the `bindhome.resolve` Home Assistant response action. Callers can resolve an Asset capability/role to structured status, current entity, configuration validity, runtime availability and state without depending on BindHome internals. ([#37](https://github.com/alessbarb/bindhome/issues/37))
+- Added assisted import from Home Assistant metadata with deterministic proposals, stable Entity Registry identity, conservative duplicate detection, explicit create/merge/skip review and one atomic commit for the reviewed batch. The panel exposes the complete review workflow without mutating Home Assistant devices or entities. ([#38](https://github.com/alessbarb/bindhome/issues/38), [#55](https://github.com/alessbarb/bindhome/issues/55), [#84](https://github.com/alessbarb/bindhome/issues/84), [#85](https://github.com/alessbarb/bindhome/issues/85), [#86](https://github.com/alessbarb/bindhome/issues/86))
+- Added actionable Home Assistant Repairs for stale Asset Areas and broken Binding targets. Issues are grouped, avoid runtime-unavailable false positives, follow stable Entity Registry renames and clear automatically when the underlying condition is repaired. ([#47](https://github.com/alessbarb/bindhome/issues/47))
+- Added a deterministic, versioned CSV inventory round-trip contract for Assets, including stable/human Area references, row-level validation, create/update semantics and transaction-safe import through administrator WebSocket commands. Bindings and topology remain outside the CSV format. ([#48](https://github.com/alessbarb/bindhome/issues/48))
+
 ### Changed
 
-- Home navigation now follows Home Assistant Floor/Area icons more closely, persists collapsed floors per HA user/browser, provides an empty-room first action and exposes an accessible refresh-in-progress state. ([#46](https://github.com/alessbarb/bindhome/issues/46))
-- Guided hardware replacement now lets administrators review compatible Home Assistant targets and atomically rebind existing Assets without changing stable Asset, topology or Representation identity. ([#39](https://github.com/alessbarb/bindhome/issues/39))
-- Logical Representation metadata ownership is now explicit: BindHome keeps the integration-provided original name and physical Area aligned with the Asset while preserving Home Assistant user overrides such as the custom entity name, `entity_id` and icon across reconciliation and restart. ([#44](https://github.com/alessbarb/bindhome/issues/44))
+- Existing Bindings now have a guided hardware-replacement workflow: compatible candidates are reviewed explicitly and revalidated immediately before the atomic replacement, preserving the Asset, topology and logical Representation while leaving the old Home Assistant hardware untouched. ([#39](https://github.com/alessbarb/bindhome/issues/39))
+- Logical Representation metadata ownership is explicit: BindHome keeps integration-provided original identity and physical Area aligned with the Asset while preserving Home Assistant user overrides such as custom entity name, `entity_id`, icon, aliases and labels. ([#44](https://github.com/alessbarb/bindhome/issues/44))
+- Casa navigation now follows Home Assistant Floor/Area icons where configured, persists collapsed Floor state, exposes clearer child counts and empty-room actions, keeps selection accessible, and gives refresh an explicit loading/disabled state. ([#46](https://github.com/alessbarb/bindhome/issues/46))
+
+### Reliability
+
+- Assisted import and hardware replacement reuse the existing Registry transaction boundary and stable Binding target identity, so validation/storage failure cannot partially adopt a reviewed batch or replace the live Binding.
+- Integrity Repairs are event-driven rather than polled and distinguish broken configuration from temporarily unavailable runtime state.
+
+### Distribution
+
+- Version promoted to `1.4.0` across Python, Home Assistant and frontend package metadata.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BindHome
 
-**Current stable release: `1.3.0` · Home Assistant `2026.8.0+`**
+**Current stable release: `1.4.0` · Home Assistant `2026.8.0+`**
 
 **Model the home, not the hardware.**
 
@@ -284,11 +284,11 @@ Existing installations that already contain Assets do not receive the first-run 
 
 ---
 
-## BindHome 1.2.0
+## BindHome 1.4.0
 
-BindHome 1.2.0 is a reliability-focused release. It keeps the public Registry schema at v1 while making future evolution and recovery safer: multi-step mutations now use a supported manager transaction boundary, historical Registry payloads migrate through explicit validated steps, failed loads expose a fail-closed Home Assistant Repair with backup recovery, and config-entry diagnostics provide aggregate support data without exporting home or hardware identifiers.
+BindHome 1.4.0 makes the stable physical model substantially easier to maintain as a real Home Assistant installation evolves. Authenticated non-admin users can browse the intended household inventory in read-only mode, while mutations, recovery and administrative surfaces remain protected. Administrators gain assisted import from Home Assistant metadata, guided hardware replacement that preserves stable Asset/Representation identity, actionable integrity Repairs, and a deterministic CSV inventory round-trip contract.
 
-The release also enforces English/Spanish translation parity and real JavaScript typechecking for the production panel source. Existing Assets, Relations, Bindings and Representations remain compatible with the 1.1 release line.
+The release also adds the `bindhome.resolve` response action for querying the current implementation of an Asset capability, formalizes ownership of logical Representation metadata versus Home Assistant user overrides, and improves Casa navigation with authoritative Floor/Area metadata, persistent collapsed Floors, clearer empty states and accessible refresh feedback. Registry schema remains v2 and the verified minimum Home Assistant release remains `2026.8.0`.
 
 ---
 

--- a/custom_components/bindhome/manifest.json
+++ b/custom_components/bindhome/manifest.json
@@ -17,5 +17,5 @@
   "issue_tracker": "https://github.com/alessbarb/bindhome/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.3.0"
+  "version": "1.4.0"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bindhome-panel",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bindhome-panel",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "lit": "^3.3.3"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bindhome-panel",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bindhome"
-version = "1.3.0"
+version = "1.4.0"
 description = "Stable home infrastructure bound to replaceable Home Assistant hardware"
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
## Summary

- promote BindHome metadata from 1.3.0 to 1.4.0 across Home Assistant, Python and frontend package metadata
- replace the stale README 1.2.0 highlight with an accurate 1.4.0 release summary and mark 1.4.0 as the current stable release
- promote the complete 1.4.0 user-visible scope from Unreleased into a dated 1.4.0 changelog section
- keep the release line based on the last pure 1.4.0 product commit (`981fba7`), before any 1.4.1 surface work landed

This PR targets the historical `release/1.4.0-base` branch intentionally. Its merge commit will be the exact commit tagged and published as `v1.4.0`; it must not include later 1.4.1 work.

The release-preparation tree already passed frontend tests, typecheck and production build before this PR. Normal repository PR CI on the final head SHA remains authoritative.