### PR TITLE
release: prepare BindHome v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,17 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 
 ## [Unreleased]
 
+---
+
+## [1.4.1] - 2026-09-06
+
+Completes the panel workflows for capabilities shipped in 1.4.0 and earlier: logical lights, model health, CSV maintenance and Registry backup/recovery. Also improves navigation and per-user preferences.
+
+**Minimum Home Assistant:** `2026.8.0`. Compatibility tested against `2026.8.0` and `2026.9.0`.
+
 ### Added
 
 - Element detail now lets administrators create and remove the existing logical light Representation with revision-bound confirmation, stable Home Assistant entity lookup, availability and capability-limit guidance; household readers see status without mutation controls. ([#101](https://github.com/alessbarb/bindhome/issues/101))
-
 - Advanced Maintenance now includes a first-class model health surface for Binding status, stale Areas, declared capabilities without Bindings, Registry recovery and undocumented Home Assistant hardware discovered through the existing assisted-import engine; actionable findings route into the supported remediation workflows. ([#100](https://github.com/alessbarb/bindhome/issues/100))
 
 ### Changed
@@ -31,6 +38,20 @@ The preferred categories are **Added**, **Changed**, **Fixed**, **Reliability**,
 - The BindHome header now exposes Home Assistant's native sidebar menu control, letting phone/narrow layouts and desktop setups with an always-hidden docked sidebar open HA navigation using the platform's own context, kiosk and notification semantics. ([#115](https://github.com/alessbarb/bindhome/issues/115))
 - Panel preferences for Advanced pinning, onboarding dismissal and collapsed Floors now persist in Home Assistant per-user frontend data so they follow the authenticated user across browsers and devices; existing browser-local values migrate once when the server preference is unset, and explicit user changes cannot be overwritten by a late asynchronous restore. ([#113](https://github.com/alessbarb/bindhome/issues/113))
 - BindHome panel views now have canonical URLs with deep-linkable Home/Area/Asset, Add, Search and Advanced routes; browser history and search query state stay synchronized without remounting active workflows. ([#109](https://github.com/alessbarb/bindhome/issues/109))
+
+### Fixed
+
+- Reconciled the already-published 1.4.0 baseline into `main` so release metadata and changelog history no longer lag the public tag. ([#122](https://github.com/alessbarb/bindhome/pull/122))
+- Updated installation, maintenance, Representation and release documentation for the shipped panel workflows, and corrected the 1.4.0/1.4.1 changelog comparison links.
+
+### Compatibility
+
+- No new Representation platforms, Registry schema migration or minimum Home Assistant change. Registry schema remains v2, the backup envelope remains v1, and the CSV format remains v1.
+- Upgrading from 1.4.0 preserves Assets, Bindings and logical identities. Export a Registry backup, update through HACS and restart Home Assistant. A return to 1.4.0 can read schema v2 but removes the new panel workflows; pre-1.3 releases cannot read schema v2 in place.
+
+### Distribution
+
+- Version synchronized to `1.4.1` in Home Assistant, Python and frontend package metadata. The publication workflow creates the tag and release only on the exact merged `main` commit after its release gates succeed.
 
 ---
 
@@ -256,7 +277,9 @@ First public BindHome release.
 
 ---
 
-[Unreleased]: https://github.com/alessbarb/bindhome/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/alessbarb/bindhome/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/alessbarb/bindhome/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/alessbarb/bindhome/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/alessbarb/bindhome/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/alessbarb/bindhome/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/alessbarb/bindhome/compare/v1.1.0...v1.1.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BindHome
 
-**Current stable release: `1.4.0` · Home Assistant `2026.8.0+`**
+**Current stable release: `1.4.1` · Home Assistant `2026.8.0+`**
 
 **Model the home, not the hardware.**
 
@@ -220,6 +220,10 @@ Not every Asset needs to become a Home Assistant entity.
 
 Represent only the Assets where a stable logical entity provides value to dashboards, scripts or automations.
 
+From **Home → room → element**, use **Logical light in Home Assistant → Create logical light** and confirm. The element needs `on_off` and a valid primary Binding. The current platform is exclusively `light`: backing lights retain the existing safely mirrored lighting capabilities; other domains expose ON/OFF only. The detail shows the actual logical entity resolved by Home Assistant, including user renames, and its current availability. Example entity IDs in this README are illustrative, not a naming contract.
+
+Removing the logical light requires confirmation and preserves the physical element, its Bindings and hardware. Dashboards, automations or other connections referencing that logical entity may need adjustment. Read-only household users can inspect status but cannot create or remove it.
+
 ---
 
 ## A complete example
@@ -284,7 +288,24 @@ Existing installations that already contain Assets do not receive the first-run 
 
 ---
 
-## BindHome 1.4.0
+## BindHome 1.4.1
+
+Version 1.4.1 completes the panel experience over the capabilities already shipped in 1.4.0 and earlier.
+
+| Workflow | Where to find it | What you can do |
+| --- | --- | --- |
+| Logical light | Home → room → element | Create/remove the existing Light Representation with confirmation; inspect its actual HA entity and availability. |
+| Model health | Advanced → Maintenance | Review broken Bindings, missing connections, stale Areas, recovery and undocumented HA hardware; open the relevant repair workflow. |
+| CSV inventory | Advanced → Maintenance | Export all Assets or one Floor/Area; validate a file, review row errors and preview changes before one transactional import. |
+| Registry backup | Advanced → Maintenance | Download a complete backup, see the last export recorded for your HA user, inspect a restore and explicitly confirm full replacement. |
+| Navigation | Panel header and URLs | Open the native HA sidebar, share direct links to views/elements and use browser Back/Forward. |
+| Preferences | Authenticated HA user | Keep Advanced pinning, onboarding dismissal and collapsed Floors across browsers and devices. |
+
+Enable **Advanced** to access administrative maintenance. Household readers retain Home/Search and status without mutation controls. Registry schema remains v2; the backup and CSV formats remain v1. The minimum HA version remains `2026.8.0`, with CI coverage for `2026.8.0` and `2026.9.0`.
+
+See the [1.4.1 changelog](CHANGELOG.md#141---2026-09-06) for the complete release history and upgrade notes.
+
+### Foundation shipped in 1.4.0
 
 BindHome 1.4.0 makes the stable physical model substantially easier to maintain as a real Home Assistant installation evolves. Authenticated non-admin users can browse the intended household inventory in read-only mode, while mutations, recovery and administrative surfaces remain protected. Administrators gain assisted import from Home Assistant metadata, guided hardware replacement that preserves stable Asset/Representation identity, actionable integrity Repairs, and a deterministic CSV inventory round-trip contract.
 
@@ -335,9 +356,11 @@ HACS update
   -> verify System Health / Registry state
 ```
 
-Back up the BindHome Registry before an important upgrade. See [Backup and restore](docs/backup-restore.md).
+For the 1.4.0 → 1.4.1 update, export a Registry backup, install 1.4.1 through HACS and restart Home Assistant. No new Registry migration is required. Then open an element detail and Advanced → Maintenance to verify the new surfaces. Back up the BindHome Registry before an important upgrade. See [Backup and restore](docs/backup-restore.md).
 
 ### Downgrade
+
+Only select a release that can read the current Registry schema. Both 1.4.0 and 1.4.1 use schema v2; releases before 1.3.0 require a compatible historical backup rather than an in-place downgrade.
 
 If a release causes a problem:
 
@@ -370,7 +393,7 @@ BindHome may use Home Assistant internal APIs that are appropriate for custom in
 
 BindHome Registry state is persistent and is deliberately treated as infrastructure data.
 
-The integration supports deterministic Registry backup/export and transactional restore through administrator-only WebSocket commands. A restore validates the complete backup before it replaces live state.
+Administrators can use **Advanced → Maintenance → Backup and restore** to download a deterministic full Registry backup and review a restore before confirming complete replacement. The panel uses the existing administrator-only WebSocket contract; a restore validates the full backup before replacing live state. CSV inventory export is separate and does not back up Bindings, Relations or Representations.
 
 See [docs/backup-restore.md](docs/backup-restore.md) for the exact format and recovery procedure.
 

--- a/custom_components/bindhome/manifest.json
+++ b/custom_components/bindhome/manifest.json
@@ -17,5 +17,5 @@
   "issue_tracker": "https://github.com/alessbarb/bindhome/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -16,7 +16,7 @@ The classification decorators are part of the runtime authorization boundary and
 
 | Surface | Access | Reason |
 | --- | --- | --- |
-| Registry get/subscribe | household-read | Canonical household inventory and live revision updates |
+| Registry get/subscribe | household-read | Canonical household inventory, transient logical entity lookup and live revision updates |
 | Preset list | household-read | Static presentation metadata |
 | Asset get/list | household-read | Physical household inventory |
 | Relation list and graph traverse/path | household-read | Household topology |
@@ -37,6 +37,6 @@ Home Assistant remains authoritative for Floor, Area, Device and Entity metadata
 
 ## Panel behavior
 
-The sidebar panel is visible to authenticated non-admin users. In household-read mode it exposes Home and Search, inventory/topology/status details and live refreshes. Add, Advanced, edit/relation/rebind/delete actions and onboarding creation flows are hidden or disabled. Backend authorization remains authoritative even if a frontend client is modified.
+The sidebar panel is visible to authenticated non-admin users. In household-read mode it exposes Home and Search, inventory/topology/status details and live refreshes. Add, Advanced, edit/relation/rebind/delete and Representation mutation actions and onboarding creation flows are hidden or disabled. Backend authorization remains authoritative even if a frontend client is modified.
 
 This pattern is intended to be reused by future topology analysis (#41) and report/export surfaces (#42): each new handler must choose household-read, admin-read or admin-write rather than duplicating ad-hoc role checks.

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -2,6 +2,14 @@
 
 BindHome exposes an administrator-only WebSocket contract for exporting and restoring the complete logical Registry without reading or editing Home Assistant `.storage` files directly.
 
+## Panel workflow — available in 1.4.1
+
+Administrators can open **Advanced → Maintenance → Backup and restore**. Download a complete JSON backup before a significant change. The last-export indication is stored per Home Assistant user; it records a successful download, not an automatic backup schedule or proof that an external copy still exists.
+
+To restore, select a backup file, inspect the object counts, acknowledge that the whole Registry will be replaced and confirm. During normal operation the panel submits the reviewed Registry revision and rejects stale restores. In recovery mode the existing recovery API can validate and restore storage even when the normal Registry manager cannot load. A stored restore followed by a failed integration reload is reported separately; use Repairs and reload the integration.
+
+Backups preserve Assets, Relations, Bindings and Representations. CSV export covers Asset inventory only and is not a substitute for a complete Registry backup. Both 1.4.0 and 1.4.1 use backup format v1 and Registry schema v2.
+
 ## Backup envelope
 
 `bindhome/backup/export` returns a versioned envelope:
@@ -49,4 +57,4 @@ Both commands require a Home Assistant administrator.
 
 A backup may contain Home Assistant entity references that have since become stale. Schema-v2 Bindings preserve both the last-known `entity_id` and, when available, the stable Home Assistant `entity_registry_id`. Historical backups are upgraded to stable Entity Registry identity only when an exact current Registry entry proves that identity; otherwise the original `entity_id` remains an explicit compatibility fallback. Runtime lookup of the current entity id is handled separately from backup migration.
 
-Do not manipulate Home Assistant `.storage` files to create or restore a BindHome backup. Use this API or a future UX built on top of it.
+Do not manipulate Home Assistant `.storage` files to create or restore a BindHome backup. Use the panel workflow or this API.

--- a/docs/csv-inventory.md
+++ b/docs/csv-inventory.md
@@ -50,3 +50,11 @@ A typical safe workflow is therefore:
 4. Review row-level errors and the create/update preview.
 5. Import using the validated Registry revision.
 6. Export again if a canonical post-import spreadsheet is required.
+
+## Panel workflow — available in 1.4.1
+
+Administrators can open **Advanced → Maintenance → CSV inventory** and export all Assets or restrict the exported rows to one current Home Assistant Floor or Area. The panel filters the canonical export; the CSV schema and backend contract are unchanged from 1.4.0.
+
+Select an edited UTF-8 file, validate it and review the complete create/update preview and row/field errors. Commit only the validated file against its reviewed Registry revision. A conflict requires another validation; the panel does not silently apply stale changes. Import scope comes from the file contents, not the current export filter.
+
+CSV never exports or imports Bindings, Relations or Representations and never deletes Assets omitted from the file. Use a Registry backup for complete recovery.

--- a/docs/integrity-repairs.md
+++ b/docs/integrity-repairs.md
@@ -44,3 +44,9 @@ Integrity Repairs are reconciled without polling. The tracker refreshes on:
 - Home Assistant Area Registry updates.
 
 This means Repairs appear and disappear as the underlying authoritative state changes, without a separate persistent BindHome issue database.
+
+## Panel health — available in 1.4.1
+
+**Advanced → Maintenance → Model health** presents the existing Binding summary, configuration faults and runtime availability separately. It also surfaces declared capabilities without Bindings, stale Home Assistant Areas, Registry recovery and hardware not yet documented in BindHome, using the existing assisted-import discovery contract.
+
+Actions open the relevant element, import review or backup/recovery workflow. An undocumented device or a deliberately unconnected capability is a review finding, not automatically a Home Assistant Repair. Temporary hardware unavailability remains runtime status. The panel reuses authoritative data and explicit refresh; it does not add polling or a persistent issue store.

--- a/docs/release.md
+++ b/docs/release.md
@@ -129,3 +129,11 @@ If installation succeeds but post-restart validation fails:
 5. restore a compatible BindHome Registry backup only through the supported recovery path if required.
 
 A failed release must never be repaired by changing Home Assistant `.storage` directly.
+
+## 1.4.1 release baseline
+
+The 1.4.0 tag remains immutable release history. Version 1.4.1 completes panel surfaces over existing contracts, uses Registry schema v2 / backup format v1 / CSV format v1, and keeps the Home Assistant 2026.8.0 minimum with compatibility coverage for 2026.8.0 and 2026.9.0.
+
+Keep README current-release and workflow descriptions, all five version values, the finalized changelog and its 1.4.0/1.4.1 comparison links coherent. Historical 1.4.0 notes must remain under 1.4.0 rather than being relabeled. Validate every feature and release PR on its final SHA, inspect comments/reviews/threads and mergeability, then merge with an expected head SHA. A new SHA invalidates previous validation evidence.
+
+The release branch must ultimately target current `main`. Let the existing publisher create `v1.4.1` and its stable release on the exact green merged `main` commit, then verify tag identity, published version and notes. Do not publish directly from the release branch or move an existing tag.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bindhome-panel",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bindhome-panel",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "lit": "^3.3.3"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bindhome-panel",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bindhome"
-version = "1.4.0"
+version = "1.4.1"
 description = "Stable home infrastructure bound to replaceable Home Assistant hardware"
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
## Release preparation
Complete the post-1.4.0 panel release with coherent README, changelog, metadata and operating documentation.

- Synchronize all five version values to 1.4.1 (manifest, pyproject, frontend package, lockfile root and root package).
- Finalize the 1.4.1 changelog from every notable change after v1.4.0, preserve 1.4.0 history, and repair the missing 1.4.0 and new 1.4.1 comparison links.
- Document logical lights, Health, CSV and backup/restore panel workflows; navigation and HA user preferences; current authorization and safe upgrade/downgrade guidance.
- Preserve Registry schema v2, backup/CSV format v1, HA minimum 2026.8.0 and the existing light-only Representation runtime.

## Validation and publication
385 backend tests and 233 frontend tests passed locally. Ruff lint/format, frontend typecheck/build, bundle synchronization and release metadata checks passed.

Dependency #125 is merged as 811f0d493c624ab97ae1fae089fbad04694d7a31. This PR now targets main. Verify every project gate against the final head SHA, review comments/reviews/threads and mergeability, then merge with expected_head_sha.

The repository owner explicitly authorized an exception only for GitHub's additional github-advanced-security managed job failing before analysis with CAPIError 400: The requested model is not supported (rerun refused by GitHub with 403). All project CI gates remain mandatory. No checks or protections have been disabled.

After merge, let the existing publisher create v1.4.1 on the exact green merged main commit, and verify tag identity, public release/version and changelog-derived notes.